### PR TITLE
Extended support for connection templates on API 300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.1.0 (2017-01-XX)
+
+### Notes
+This release extends the full support for the Synergy and C7000 APIs to all the resources previously supported in version 1.0.0, and a few new resources specific to API300.
+
+### Features supported
+- Ethernet network
+- FC network
+- FCOE network
+- Network set
+- Fabric
+- Connection template
+
+
 # 2.0.0 (2017-01-05)
 
 ### Notes

--- a/lib/puppet/provider/oneview_connection_template/c7000.rb
+++ b/lib/puppet/provider/oneview_connection_template/c7000.rb
@@ -18,7 +18,7 @@ require_relative '../login'
 require_relative '../common'
 require 'oneview-sdk'
 
-Puppet::Type.type(:oneview_connection_template).provide(:oneview_connection_template) do
+Puppet::Type.type(:oneview_connection_template).provide(:c7000) do
   mk_resource_methods
 
   def initialize(*args)

--- a/lib/puppet/provider/oneview_connection_template/synergy.rb
+++ b/lib/puppet/provider/oneview_connection_template/synergy.rb
@@ -1,0 +1,26 @@
+################################################################################
+# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+Puppet::Type.type(:oneview_connection_template).provide :synergy, parent: :c7000 do
+  desc 'Provider for OneView Fiber Channel Networks using the Synergy variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'Synergy'
+
+  def initialize(*args)
+    @resourcetype ||= Object.const_get("OneviewSDK::API#{login[:api_version]}::Synergy::ConnectionTemplate")
+    super(*args)
+  end
+end

--- a/spec/integration/provider/oneview_connection_template_spec.rb
+++ b/spec/integration/provider/oneview_connection_template_spec.rb
@@ -16,7 +16,7 @@
 
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:oneview_connection_template).provider(:oneview_connection_template)
+provider_class = Puppet::Type.type(:oneview_connection_template).provider(:c7000)
 
 # you must have this connection template in your appliance
 
@@ -45,7 +45,7 @@ describe provider_class do
   end
 
   it 'should be an instance of the provider Ruby' do
-    expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_connection_template).provider(:oneview_connection_template)
+    expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_connection_template).provider(:c7000)
   end
 
   it 'should be able to get the default connection template' do

--- a/spec/unit/provider/oneview_connection_template_spec.rb
+++ b/spec/unit/provider/oneview_connection_template_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
-provider_class = Puppet::Type.type(:oneview_connection_template).provider(:oneview_connection_template)
+provider_class = Puppet::Type.type(:oneview_connection_template).provider(:c7000)
 resourcetype = OneviewSDK::ConnectionTemplate
 
 describe provider_class, unit: true do
@@ -41,7 +41,7 @@ describe provider_class, unit: true do
     let(:instance) { provider.class.instances.first }
 
     it 'should be an instance of the provider Ruby' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_connection_template).provider(:oneview_connection_template)
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_connection_template).provider(:c7000)
     end
 
     it 'should return that the resource exists' do


### PR DESCRIPTION
### Description
Adds the C7000 and Synergy providers with support for the resource on API300

### Issues Resolved
#7 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
