### PR TITLE
Firmware Bundle & Firmware Driver API300 Support

### DIFF
--- a/lib/puppet/provider/oneview_firmware_bundle/c7000.rb
+++ b/lib/puppet/provider/oneview_firmware_bundle/c7000.rb
@@ -14,20 +14,24 @@
 # limitations under the License.
 ################################################################################
 
-require_relative '../login'
-require_relative '../common'
-require 'oneview-sdk'
+require_relative '../oneview_resource'
 
-Puppet::Type.type(:oneview_firmware_bundle).provide(:oneview_firmware_bundle) do
+Puppet::Type::Oneview_firmware_bundle.provide :c7000, parent: Puppet::OneviewResource do
+  desc 'Provider for OneView Firmware Bundles using the C7000 variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'C7000'
+
   mk_resource_methods
 
+  @resourcetype ||= OneviewSDK::FirmwareBundle
+
   def initialize(*args)
+    @resource_name = 'FirmwareBundle'
     super(*args)
-    @client = OneviewSDK::Client.new(login)
-    @resourcetype = OneviewSDK::FirmwareBundle
-    # Initializes the data so it is parsed only on exists and accessible throughout the methods
-    # This is not set here due to the 'resources' variable not being accessible in initialize
-    @data = {}
+  end
+
+  def self.instances
+    raise Puppet::Error, 'This resource cannot be queried. Please use the Oneview_firmware_driver provider instead'
   end
 
   # Provider methods
@@ -37,7 +41,7 @@ Puppet::Type.type(:oneview_firmware_bundle).provide(:oneview_firmware_bundle) do
   end
 
   def create
-    @resourcetype.add(@client, @data['firmware_bundle_path'])
+    @resourcetype.add(@client, @data['firmware_bundle_path'], @data['timeout'])
   end
 
   def destroy

--- a/lib/puppet/provider/oneview_firmware_bundle/synergy.rb
+++ b/lib/puppet/provider/oneview_firmware_bundle/synergy.rb
@@ -1,0 +1,26 @@
+################################################################################
+# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+Puppet::Type.type(:oneview_firmware_bundle).provide :synergy, parent: :c7000 do
+  desc 'Provider for OneView Firmware Bundles using the Synergy variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'Synergy'
+
+  def initialize(*args)
+    @resourcetype ||= Object.const_get("OneviewSDK::API#{login[:api_version]}::Synergy::FirmwareBundle")
+    super(*args)
+  end
+end

--- a/lib/puppet/provider/oneview_firmware_driver/c7000.rb
+++ b/lib/puppet/provider/oneview_firmware_driver/c7000.rb
@@ -14,33 +14,21 @@
 # limitations under the License.
 ################################################################################
 
-require_relative '../login'
-require_relative '../common'
-require 'oneview-sdk'
+require_relative '../oneview_resource'
 
-Puppet::Type.type(:oneview_firmware_driver).provide(:oneview_firmware_driver) do
+Puppet::Type::Oneview_firmware_driver.provide :c7000, parent: Puppet::OneviewResource do
+  desc 'Provider for OneView Firmware Drivers using the C7000 variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'C7000'
+
   mk_resource_methods
 
-  def initialize(*args)
-    super(*args)
-    @client = OneviewSDK::Client.new(login)
-    @resourcetype = OneviewSDK::FirmwareDriver
-    # Initializes the data so it is parsed only on exists and accessible throughout the methods
-    # This is not set here due to the 'resources' variable not being accessible in initialize
-    @data = {}
-    @attributes = {}
-  end
+  @resourcetype ||= OneviewSDK::FirmwareDriver
 
-  def self.instances
-    @client = OneviewSDK::Client.new(login)
-    matches = OneviewSDK::FirmwareDriver.get_all(@client)
-    matches.collect do |line|
-      name = line['name']
-      data = line.inspect
-      new(name: name,
-          ensure: :present,
-          data: data)
-    end
+  def initialize(*args)
+    @resource_name = 'FirmwareDriver'
+    super(*args)
+    @attributes = {}
   end
 
   # Provider methods

--- a/lib/puppet/provider/oneview_firmware_driver/synergy.rb
+++ b/lib/puppet/provider/oneview_firmware_driver/synergy.rb
@@ -1,0 +1,26 @@
+################################################################################
+# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+Puppet::Type.type(:oneview_firmware_driver).provide :synergy, parent: :c7000 do
+  desc 'Provider for OneView Firmware Drivers using the Synergy variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'Synergy'
+
+  def initialize(*args)
+    @resourcetype ||= Object.const_get("OneviewSDK::API#{login[:api_version]}::Synergy::FirmwareDriver")
+    super(*args)
+  end
+end

--- a/spec/integration/provider/oneview_firmware_bundle_spec.rb
+++ b/spec/integration/provider/oneview_firmware_bundle_spec.rb
@@ -15,9 +15,9 @@
 ################################################################################
 
 require 'spec_helper'
-require File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/puppet/provider/', 'login'))
+require_relative '../../../lib/puppet/provider/login'
 
-provider_class = Puppet::Type.type(:oneview_firmware_bundle).provider(:oneview_firmware_bundle)
+provider_class = Puppet::Type.type(:oneview_firmware_bundle).provider(:c7000)
 firmware_bundle_path = login[:firmware_bundle_path] || './spec/support/cp022594.exe'
 
 describe provider_class do
@@ -41,8 +41,8 @@ describe provider_class do
   let(:instance) { provider.class.instances.first }
 
   context 'given the minimum parameters' do
-    it 'should be an instance of the provider oneview_firmware_bundle' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_bundle).provider(:oneview_firmware_bundle)
+    it 'should be an instance of the provider c7000' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_bundle).provider(:c7000)
     end
 
     it 'should raise error when firmware bundle is not found' do

--- a/spec/integration/provider/oneview_firmware_driver_spec.rb
+++ b/spec/integration/provider/oneview_firmware_driver_spec.rb
@@ -15,9 +15,9 @@
 ################################################################################
 
 require 'spec_helper'
-require File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/puppet/provider/', 'login'))
+require_relative '../../../lib/puppet/provider/login'
 
-provider_class = Puppet::Type.type(:oneview_firmware_driver).provider(:oneview_firmware_driver)
+provider_class = Puppet::Type.type(:oneview_firmware_driver).provider(:c7000)
 firmware_baseline_name = login[:firmware_baseline_name] || 'Service Pack for ProLiant'
 firmware_hotfix_names = login[:firmware_hotfix_names] || ['Online ROM Flash Component for Windows x64 - HPE ProLiant XL260a Gen9 Server']
 
@@ -43,7 +43,7 @@ describe provider_class do
 
   context 'given the minimum parameters' do
     it 'should be an instance of the provider oneview_firmware_driver' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_driver).provider(:oneview_firmware_driver)
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_driver).provider(:c7000)
     end
 
     it 'should raise error when Firmware Driver is not found' do

--- a/spec/unit/provider/oneview_firmware_bundle_spec.rb
+++ b/spec/unit/provider/oneview_firmware_bundle_spec.rb
@@ -16,7 +16,7 @@
 
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:oneview_firmware_bundle).provider(:oneview_firmware_bundle)
+provider_class = Puppet::Type.type(:oneview_firmware_bundle).provider(:c7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -44,7 +44,7 @@ describe provider_class, unit: true do
     end
 
     it 'should be an instance of the provider oneview_firmware_bundle' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_bundle).provider(:oneview_firmware_bundle)
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_bundle).provider(:c7000)
     end
 
     it 'should raise error when firmware bundle is not found' do

--- a/spec/unit/provider/oneview_firmware_driver_spec.rb
+++ b/spec/unit/provider/oneview_firmware_driver_spec.rb
@@ -16,7 +16,7 @@
 
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:oneview_firmware_driver).provider(:oneview_firmware_driver)
+provider_class = Puppet::Type.type(:oneview_firmware_driver).provider(:c7000)
 resourcetype = OneviewSDK::FirmwareDriver
 
 describe provider_class, unit: true do
@@ -39,7 +39,7 @@ describe provider_class, unit: true do
 
   context 'given the minimum parameters' do
     it 'should be an instance of the provider oneview_firmware_driver' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_driver).provider(:oneview_firmware_driver)
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_driver).provider(:c7000)
     end
 
     it 'should raise error when Firmware Driver is not found' do


### PR DESCRIPTION
Adding support for the API300 Synergy and C7000 variants to the Oneview_firmware_bundle and Oneview_firmware_driver resources

### Description
Extends support for the API300 Synergy and C7000 variants to the Oneview_firmware_bundle and Oneview_firmware_driver providers.

### Issues Resolved
#11 , #12 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
