### PR TITLE
Interconnect API300 Support

### DIFF
--- a/examples/interconnect.pp
+++ b/examples/interconnect.pp
@@ -21,7 +21,7 @@ oneview_interconnect{'Interconnect Get Types':
 oneview_interconnect{'Interconnect Found':
   ensure => 'found',
   data   => {
-    name => 'Encl2, interconnect 1'
+    name => 'Encl1, interconnect 2'
   }
 }
 
@@ -33,7 +33,7 @@ oneview_interconnect{'Interconnect Found All':
 oneview_interconnect{'Interconnect Get Specific Statistics':
   ensure => 'get_statistics',
   data   => {
-    name       => 'Encl2, interconnect 2',
+    name       => 'Encl1, interconnect 2',
     statistics =>
     {
       portName => 'X1'
@@ -45,14 +45,14 @@ oneview_interconnect{'Interconnect Get Specific Statistics':
 oneview_interconnect{'Interconnect Get Name Servers':
   ensure => 'get_name_servers',
   data   => {
-    name => 'Encl2, interconnect 1'
+    name => 'Encl1, interconnect 2'
   }
 }
 
 oneview_interconnect{'Interconnect Patch Interconnect':
   ensure => 'present',
   data   => {
-    name  => 'Encl2, interconnect 1',
+    name  => 'Encl1, interconnect 2',
     patch =>
     {
       op    => 'replace',
@@ -65,7 +65,7 @@ oneview_interconnect{'Interconnect Patch Interconnect':
 oneview_interconnect{'Interconnect Reset Port Protection':
   ensure => 'reset_port_protection',
   data   => {
-    name => 'Encl2, interconnect 1',
+    name => 'Encl1, interconnect 2',
   }
 }
 
@@ -75,7 +75,7 @@ oneview_interconnect{'Interconnect Update Ports':
   ensure => 'update_ports',
   data   =>
   {
-    name  => 'Encl2, interconnect 1',
+    name  => 'Encl1, interconnect 2',
     ports =>
       [
         {
@@ -87,5 +87,13 @@ oneview_interconnect{'Interconnect Update Ports':
           enabled  => false
         }
       ]
+  }
+}
+
+# The data and name filters are optional
+oneview_interconnect{'Interconnect Get Link Topologies':
+  ensure => 'get_link_topologies',
+  data   => {
+    name => 'name-1138866186-1483549608039',
   }
 }

--- a/examples/interconnect.pp
+++ b/examples/interconnect.pp
@@ -1,5 +1,5 @@
 ################################################################################
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.

--- a/examples/login_for_integration_synergy_tests.json
+++ b/examples/login_for_integration_synergy_tests.json
@@ -5,7 +5,7 @@
   "ssl_enabled": "true",
   "api_version": 300,
   "log_level": "info",
-  "hardware_variant": "C7000",
+  "hardware_variant": "Synergy",
   "enclosure_ip": "172.18.1.13",
   "enclosure_username": "dcs",
   "enclosure_password": "dcs",

--- a/lib/puppet/provider/oneview_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_interconnect/c7000.rb
@@ -32,12 +32,10 @@ Puppet::Type::Oneview_interconnect.provide :c7000, parent: Puppet::OneviewResour
 
   def exists?
     @data = data_parse
-    puts resource['ensure']
     empty_data_check([nil, :found, :get_types, :get_link_topologies])
     variable_assignments
     # Checks if there is a patch update to be performed
     get_single_resource_instance.patch(@patch['op'], @patch['path'], @patch['value']) if @patch
-    puts @resourcetype
     !@resourcetype.find_by(@client, @data).empty?
   end
 

--- a/lib/puppet/provider/oneview_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_interconnect/c7000.rb
@@ -32,10 +32,12 @@ Puppet::Type::Oneview_interconnect.provide :c7000, parent: Puppet::OneviewResour
 
   def exists?
     @data = data_parse
+    puts resource['ensure']
     empty_data_check([nil, :found, :get_types, :get_link_topologies])
     variable_assignments
     # Checks if there is a patch update to be performed
     get_single_resource_instance.patch(@patch['op'], @patch['path'], @patch['value']) if @patch
+    puts @resourcetype
     !@resourcetype.find_by(@client, @data).empty?
   end
 
@@ -58,6 +60,7 @@ Puppet::Type::Oneview_interconnect.provide :c7000, parent: Puppet::OneviewResour
     else
       pretty @resourcetype.get_types(@client)
     end
+    true
   end
 
   # it is possible to query by either portName, subportNumber or nothing (for all)

--- a/lib/puppet/provider/oneview_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_interconnect/c7000.rb
@@ -1,5 +1,5 @@
 ################################################################################
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.

--- a/lib/puppet/provider/oneview_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_interconnect/c7000.rb
@@ -32,7 +32,7 @@ Puppet::Type::Oneview_interconnect.provide :c7000, parent: Puppet::OneviewResour
 
   def exists?
     @data = data_parse
-    empty_data_check([nil, :found, :get_types])
+    empty_data_check([nil, :found, :get_types, :get_link_topologies])
     variable_assignments
     # Checks if there is a patch update to be performed
     get_single_resource_instance.patch(@patch['op'], @patch['path'], @patch['value']) if @patch
@@ -92,6 +92,10 @@ Puppet::Type::Oneview_interconnect.provide :c7000, parent: Puppet::OneviewResour
   def reset_port_protection
     Puppet.notice("\n\nResetting Port Protection...\n")
     get_single_resource_instance.reset_port_protection
+  end
+
+  def get_link_topologies
+    raise 'This ensure method is only supported by the Synergy resource variant'
   end
 
   # Helpers

--- a/lib/puppet/provider/oneview_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_interconnect/c7000.rb
@@ -14,23 +14,25 @@
 # limitations under the License.
 ################################################################################
 
-require_relative '../login'
-require_relative '../common'
-require 'oneview-sdk'
+require_relative '../oneview_resource'
 
-Puppet::Type.type(:oneview_interconnect).provide(:oneview_interconnect) do
+Puppet::Type::Oneview_interconnect.provide :c7000, parent: Puppet::OneviewResource do
+  desc 'Provider for OneView Interconnects using the C7000 variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'C7000'
+
   mk_resource_methods
 
+  @resourcetype ||= OneviewSDK::Interconnect
+
   def initialize(*args)
+    @resource_name = 'Interconnect'
     super(*args)
-    @client = OneviewSDK::Client.new(login)
-    @resourcetype = OneviewSDK::Interconnect
-    @data = {}
   end
 
   def exists?
     @data = data_parse
-    empty_data_check([:found, :get_types])
+    empty_data_check([nil, :found, :get_types])
     variable_assignments
     # Checks if there is a patch update to be performed
     get_single_resource_instance.patch(@patch['op'], @patch['path'], @patch['value']) if @patch

--- a/lib/puppet/provider/oneview_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_interconnect/synergy.rb
@@ -1,0 +1,26 @@
+################################################################################
+# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+Puppet::Type.type(:oneview_interconnect).provide :synergy, parent: :c7000 do
+  desc 'Provider for OneView Interconnects using the Synergy variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'Synergy'
+
+  def initialize(*args)
+    @resourcetype ||= Object.const_get("OneviewSDK::API#{login[:api_version]}::Synergy::Interconnect")
+    super(*args)
+  end
+end

--- a/lib/puppet/provider/oneview_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_interconnect/synergy.rb
@@ -1,5 +1,5 @@
 ################################################################################
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.

--- a/lib/puppet/provider/oneview_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_interconnect/synergy.rb
@@ -23,4 +23,13 @@ Puppet::Type.type(:oneview_interconnect).provide :synergy, parent: :c7000 do
     @resourcetype ||= Object.const_get("OneviewSDK::API#{login[:api_version]}::Synergy::Interconnect")
     super(*args)
   end
+
+  def get_link_topologies
+    Puppet.notice("\n\nInterconnect link topologies:\n")
+    if @data['name']
+      pretty @resourcetype.get_link_topology(@client, @data['name'])
+    else
+      pretty @resourcetype.get_link_topologies(@client)
+    end
+  end
 end

--- a/lib/puppet/provider/oneview_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_interconnect/synergy.rb
@@ -18,6 +18,7 @@ Puppet::Type.type(:oneview_interconnect).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Interconnects using the Synergy variant of the OneView API'
 
   confine true: login[:hardware_variant] == 'Synergy'
+  defaultfor oneview_synergy_variant: 'Synergy'
 
   def initialize(*args)
     @resourcetype ||= Object.const_get("OneviewSDK::API#{login[:api_version]}::Synergy::Interconnect")
@@ -31,5 +32,6 @@ Puppet::Type.type(:oneview_interconnect).provide :synergy, parent: :c7000 do
     else
       pretty @resourcetype.get_link_topologies(@client)
     end
+    true
   end
 end

--- a/lib/puppet/type/oneview_interconnect.rb
+++ b/lib/puppet/type/oneview_interconnect.rb
@@ -25,6 +25,10 @@ Puppet::Type.newtype(:oneview_interconnect) do
       provider.found
     end
 
+    newvalue(:get_link_topologies) do
+      provider.get_link_topologies
+    end
+
     # GETs
     newvalue(:get_interconnect_type) do
       provider.get_interconnect_type

--- a/spec/integration/provider/oneview_interconnect_c7000_spec.rb
+++ b/spec/integration/provider/oneview_interconnect_c7000_spec.rb
@@ -1,5 +1,5 @@
 ################################################################################
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ describe provider_class do
       provider.exists?
     end
 
-    it 'should be an instance of the provider Ruby' do
+    it 'should be an instance of the provider C7000' do
       expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_interconnect).provider(:c7000)
     end
 

--- a/spec/integration/provider/oneview_interconnect_spec.rb
+++ b/spec/integration/provider/oneview_interconnect_spec.rb
@@ -75,5 +75,9 @@ describe provider_class do
     it 'should update the interconnect port x1' do
       expect(provider.update_ports).to be
     end
+
+    it 'should run get link topologies and display an error' do
+      expect(provider.get_link_topologies).to raise_error('This ensure method is only supported by the Synergy resource variant.')
+    end
   end
 end

--- a/spec/integration/provider/oneview_interconnect_spec.rb
+++ b/spec/integration/provider/oneview_interconnect_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 # you must have the interconnect in your appliance
 
-provider_class = Puppet::Type.type(:oneview_interconnect).provider(:oneview_interconnect)
+provider_class = Puppet::Type.type(:oneview_interconnect).provider(:c7000)
 
 describe provider_class do
   let(:resource) do
@@ -43,15 +43,15 @@ describe provider_class do
 
   let(:instance) { provider.class.instances.first }
 
-  before(:each) do
-    provider.exists?
-  end
-
-  it 'should be an instance of the provider Ruby' do
-    expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_interconnect).provider(:oneview_interconnect)
-  end
-
   context 'given the min parameters' do
+    before(:each) do
+      provider.exists?
+    end
+
+    it 'should be an instance of the provider Ruby' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_interconnect).provider(:c7000)
+    end
+
     it 'exists? should return true' do
       expect(provider.exists?).to be
     end

--- a/spec/integration/provider/oneview_interconnect_synergy_spec.rb
+++ b/spec/integration/provider/oneview_interconnect_synergy_spec.rb
@@ -1,0 +1,84 @@
+################################################################################
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+
+# you must have the interconnect in your appliance
+
+provider_class = Puppet::Type.type(:oneview_interconnect).provider(:synergy)
+
+describe provider_class do
+  let(:resource) do
+    Puppet::Type.type(:oneview_interconnect).new(
+      name: 'interconnect',
+      ensure: 'present',
+      data:
+          {
+            'name' => 'Encl2, interconnect 1',
+            'ports' =>
+                [
+                  {
+                    'portName' => 'X1',
+                    'enabled' => false
+                  }
+                ]
+          },
+      provider: 'synergy'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  context 'given the min parameters' do
+    before(:each) do
+      provider.exists?
+    end
+
+    it 'should be an instance of the provider Synergy' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_interconnect).provider(:synergy)
+    end
+
+    it 'exists? should return true' do
+      expect(provider.exists?).to be
+    end
+
+    it 'should display the statistics' do
+      expect(provider.get_statistics).to be
+    end
+
+    it 'should return the interconnects' do
+      expect(provider.found).to be
+    end
+
+    it 'should run destroy and display an error' do
+      expect { provider.destroy }.to raise_error('This resource relies on others to be destroyed.')
+    end
+
+    it 'should run create and display an error' do
+      expect { provider.create }.to raise_error('This resource relies on others to be created.')
+    end
+
+    it 'should update the interconnect port x1' do
+      expect(provider.update_ports).to be
+    end
+
+    it 'should run get link topologies and display an error' do
+      expect(provider.get_link_topologies).to raise_error('This ensure method is only supported by the Synergy resource variant.')
+    end
+  end
+end

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -23,7 +23,7 @@ begin
   JSON.parse(File.read(File.absolute_path(ENV['ONEVIEW_INTEGRATION_CONFIG'])), symbolize_names: true)
   JSON.parse(File.read(File.absolute_path(ENV['ONEVIEW_INTEGRATION_SECRETS'])), symbolize_names: true)
 rescue Errno::ENOENT
-  puts 'bla'
+  puts 'No Integration Config and/or Secrets files have been found. Intergration tests will not be able to run.'
 end
 
 # General context for unit testing:

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -1,5 +1,5 @@
 ################################################################################
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -14,18 +14,6 @@
 # limitations under the License.
 ################################################################################
 
-# Context for integration testing:
-# WARNING: Communicates with & modifies a real instance.
-# Must set the following environment variables:
-ENV['ONEVIEW_INTEGRATION_CONFIG'] ||= 'spec/integration/oneview_config.json'
-ENV['ONEVIEW_INTEGRATION_SECRETS'] ||= 'spec/integration/oneview_secrets.json'
-begin
-  JSON.parse(File.read(File.absolute_path(ENV['ONEVIEW_INTEGRATION_CONFIG'])), symbolize_names: true)
-  JSON.parse(File.read(File.absolute_path(ENV['ONEVIEW_INTEGRATION_SECRETS'])), symbolize_names: true)
-rescue Errno::ENOENT
-  puts 'No Integration Config and/or Secrets files have been found. Intergration tests will not be able to run.'
-end
-
 # General context for unit testing:
 RSpec.shared_context 'shared context', a: :b do
   before :each do
@@ -36,6 +24,17 @@ RSpec.shared_context 'shared context', a: :b do
 end
 
 RSpec.shared_context 'integration context', a: :b do
+  # Context for integration testing:
+  # WARNING: Communicates with & modifies a real instance.
+  # Must set the following environment variables:
+  ENV['ONEVIEW_INTEGRATION_CONFIG'] ||= 'spec/integration/oneview_config.json'
+  ENV['ONEVIEW_INTEGRATION_SECRETS'] ||= 'spec/integration/oneview_secrets.json'
+  begin
+    JSON.parse(File.read(File.absolute_path(ENV['ONEVIEW_INTEGRATION_CONFIG'])), symbolize_names: true)
+    JSON.parse(File.read(File.absolute_path(ENV['ONEVIEW_INTEGRATION_SECRETS'])), symbolize_names: true)
+  rescue Errno::ENOENT
+    raise 'No Integration Config and/or Secrets files have been found. Integration tests will not be able to run.'
+  end
   # Ensure config & secrets files exist
   before :all do
     default_config  = 'spec/integration/oneview_config.json'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,7 +80,6 @@ RSpec.configure do |config|
   config.before(:each) do
     # TODO: Puppet: Probably reverify this once we have have different test profiles
     if config.filter_manager.inclusions.rules[:unit]
-      # unless config.filter_manager.inclusions.rules[:integration] || config.filter_manager.inclusions.rules[:system]
       # Mock appliance version and login api requests, as well as loading trusted certs
       allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(300)
       allow_any_instance_of(OneviewSDK::Client).to receive(:login).and_return('secretToken')

--- a/spec/unit/provider/oneview_interconnect_c7000_spec.rb
+++ b/spec/unit/provider/oneview_interconnect_c7000_spec.rb
@@ -58,9 +58,19 @@ describe provider_class, unit: true do
       expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_interconnect).provider(:c7000)
     end
 
+    it 'should be able to find the interconnects' do
+      allow(resourcetype).to receive(:find_by).and_return([test])
+      expect(provider.found).to be
+    end
+
     it 'should be able to get the name servers' do
       allow_any_instance_of(resourcetype).to receive(:name_servers).and_return('Test')
       expect(provider.get_name_servers).to be
+    end
+
+    it 'should be able to get the types filtered by a name' do
+      allow(resourcetype).to receive(:get_type).and_return('Test')
+      expect(provider.get_types).to be
     end
 
     it 'should be able to get the statistics' do
@@ -76,6 +86,14 @@ describe provider_class, unit: true do
     it 'should be able to update the ports' do
       allow_any_instance_of(resourcetype).to receive(:update_port).and_return('Test')
       expect(provider.update_ports).to be
+    end
+
+    it 'should raise an error when trying to destroy a resource' do
+      expect { provider.destroy }.to raise_error(/This resource relies on others to be destroyed/)
+    end
+
+    it 'should raise an error when trying to run get_link_topologies' do
+      expect { provider.get_link_topologies }.to raise_error(/This ensure method is only supported by the Synergy resource variant/)
     end
   end
 end

--- a/spec/unit/provider/oneview_interconnect_c7000_spec.rb
+++ b/spec/unit/provider/oneview_interconnect_c7000_spec.rb
@@ -1,5 +1,5 @@
 ################################################################################
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.
@@ -38,7 +38,8 @@ describe provider_class, unit: true do
                 'enabled' => true
               }
             ]
-          }
+          },
+      provider: 'c7000'
     )
   end
 

--- a/spec/unit/provider/oneview_interconnect_spec.rb
+++ b/spec/unit/provider/oneview_interconnect_spec.rb
@@ -18,43 +18,44 @@ require 'spec_helper'
 require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
-provider_class = Puppet::Type.type(:oneview_interconnect).provider(:oneview_interconnect)
+provider_class = Puppet::Type.type(:oneview_interconnect).provider(:c7000)
 resourcetype = OneviewSDK::Interconnect
 
 describe provider_class, unit: true do
   include_context 'shared context'
 
+  let(:resource) do
+    Puppet::Type.type(:oneview_interconnect).new(
+      name: 'Interconnect',
+      ensure: 'present',
+      data:
+          {
+            'name' => 'Encl2, interconnect 1',
+            'ports' =>
+            [
+              {
+                'portName' => 'x1',
+                'enabled' => true
+              }
+            ]
+          }
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  let(:test) { resourcetype.new(@client, resource['data']) }
+
   context 'given the min parameters' do
-    let(:resource) do
-      Puppet::Type.type(:oneview_interconnect).new(
-        name: 'Interconnect',
-        ensure: 'present',
-        data:
-            {
-              'name' => 'Encl2, interconnect 1',
-              'ports' =>
-              [
-                {
-                  'portName' => 'x1',
-                  'enabled' => true
-                }
-              ]
-            }
-      )
-    end
-
-    let(:provider) { resource.provider }
-
-    let(:instance) { provider.class.instances.first }
-
     before(:each) do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resourcetype).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
     it 'should be an instance of the provider Ruby' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_interconnect).provider(:oneview_interconnect)
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_interconnect).provider(:c7000)
     end
 
     it 'should be able to get the name servers' do

--- a/spec/unit/provider/oneview_interconnect_synergy_spec.rb
+++ b/spec/unit/provider/oneview_interconnect_synergy_spec.rb
@@ -18,8 +18,6 @@ require 'spec_helper'
 require_relative '../../shared_context'
 require_relative '../../support/fake_response'
 
-ENV['ONEVIEW_AUTH_FILE'] = 'C:/Users/garciabf/puppet/my_oneview_300_synergy_login.json'
-
 provider_class = Puppet::Type.type(:oneview_interconnect).provider(:synergy)
 resourcetype = OneviewSDK::API300::Synergy::Interconnect
 describe provider_class, unit: true do

--- a/spec/unit/provider/oneview_interconnect_synergy_spec.rb
+++ b/spec/unit/provider/oneview_interconnect_synergy_spec.rb
@@ -1,0 +1,123 @@
+################################################################################
+# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+require_relative '../../shared_context'
+require_relative '../../support/fake_response'
+
+ENV['ONEVIEW_AUTH_FILE'] = 'C:/Users/garciabf/puppet/my_oneview_300_synergy_login.json'
+
+provider_class = Puppet::Type.type(:oneview_interconnect).provider(:synergy)
+resourcetype = OneviewSDK::API300::Synergy::Interconnect
+describe provider_class, unit: true do
+  include_context 'shared context'
+  let(:resource) do
+    Puppet::Type.type(:oneview_interconnect).new(
+      name: 'Interconnect',
+      ensure: 'present',
+      data:
+          {
+            'name' => 'Encl2, interconnect 1',
+            'ports' =>
+            [
+              {
+                'portName' => 'x1',
+                'enabled' => true
+              }
+            ]
+          },
+      provider: 'synergy'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  let(:test) { resourcetype.new(@client, resource['data']) }
+
+  context 'given the min parameters' do
+    before(:each) do
+      allow(resourcetype).to receive(:find_by).and_return([test])
+      provider.exists?
+    end
+
+    it 'should be an instance of the provider Synergy' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_interconnect).provider(:synergy)
+    end
+
+    it 'should be able to get the name servers' do
+      allow_any_instance_of(resourcetype).to receive(:name_servers).and_return('Test')
+      expect(provider.get_name_servers).to be
+    end
+
+    it 'should be able to get the statistics' do
+      allow_any_instance_of(resourcetype).to receive(:statistics).and_return('Test')
+      expect(provider.get_statistics).to be
+    end
+
+    it 'should be able to get the statistics' do
+      resource['data']['statistics'] = {}
+      resource['data']['statistics']['portName'] = 'portname'
+      resource['data']['statistics']['subportNumber'] = 'subportname'
+      allow_any_instance_of(resourcetype).to receive(:statistics).and_return('Test')
+      provider.exists?
+      expect(provider.get_statistics).to be
+    end
+
+    it 'should be able to reset the port protection' do
+      allow_any_instance_of(resourcetype).to receive(:reset_port_protection).and_return('Test')
+      expect(provider.reset_port_protection).to be
+    end
+
+    it 'should be able to update the ports' do
+      allow(resourcetype).to receive(:update_port).and_return('Test')
+      expect(provider.update_ports).to be
+    end
+
+    it 'should be able to get the link topologies' do
+      allow(resourcetype).to receive(:get_link_topologies).and_return(['Test'])
+      expect(provider.get_link_topologies).to be
+    end
+
+    it 'should raise an error when trying to create a resource' do
+      expect { provider.create }.to raise_error(/This resource relies on others to be created/)
+    end
+  end
+  context 'given the min parameters' do
+    before(:each) do
+      allow(resourcetype).to receive(:find_by).and_return([])
+      provider.exists?
+    end
+    let(:resource) do
+      Puppet::Type.type(:oneview_interconnect).new(
+        name: 'Interconnect',
+        ensure: 'get_link_topologies',
+        provider: 'synergy'
+      )
+    end
+
+    it 'should be able to get all the link topologies' do
+      allow(resourcetype).to receive(:get_link_topologies).and_return(['Test'])
+      expect(provider.get_link_topologies).to be
+    end
+
+    it 'should be able to get all the link topologies' do
+      allow(resourcetype).to receive(:get_types).and_return(['Test'])
+      expect(provider.get_types).to be
+    end
+  end
+end

--- a/spec/unit/provider/oneview_interconnect_synergy_spec.rb
+++ b/spec/unit/provider/oneview_interconnect_synergy_spec.rb
@@ -1,5 +1,5 @@
 ################################################################################
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description
Extends support to API300 Synergy and C7000 for the Oneview_interconnect type

### Issues Resolved
#13 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
