### PR TITLE
Oneview_logical_interconnect API300 Support

### DIFF
--- a/lib/puppet/provider/oneview_logical_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect/c7000.rb
@@ -14,19 +14,14 @@
 # limitations under the License.
 ################################################################################
 
-require_relative '../login'
-require_relative '../common'
-require 'oneview-sdk'
+require_relative '../oneview_resource'
 
-Puppet::Type.type(:oneview_logical_interconnect).provide(:oneview_logical_interconnect) do
+Puppet::Type::Oneview_logical_interconnect.provide :c7000, parent: Puppet::OneviewResource do
+  desc 'Provider for OneView Logical Interconnects using the C7000 variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'C7000'
+
   mk_resource_methods
-
-  def initialize(*args)
-    super(*args)
-    @client = OneviewSDK::Client.new(login)
-    @resourcetype = OneviewSDK::LogicalInterconnect
-    @data = {}
-  end
 
   def exists?
     @data = data_parse

--- a/lib/puppet/provider/oneview_logical_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect/synergy.rb
@@ -1,0 +1,21 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+Puppet::Type.type(:oneview_logical_interconnect).provide :synergy, parent: :c7000 do
+  desc 'Provider for OneView Logical Interconnects using the Synergy variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'Synergy'
+end

--- a/spec/integration/provider/oneview_logical_interconnect_c7000_spec.rb
+++ b/spec/integration/provider/oneview_logical_interconnect_c7000_spec.rb
@@ -16,7 +16,7 @@
 
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:oneview_logical_interconnect).provider(:oneview_logical_interconnect)
+provider_class = Puppet::Type.type(:oneview_logical_interconnect).provider(:c7000)
 
 describe provider_class do
   let(:resource) do
@@ -37,7 +37,8 @@ describe provider_class do
                 'isoFileName' => 'fake_firmware.iso',
                 'force' => false
               }
-          }
+          },
+      provider: 'c7000'
     )
   end
 
@@ -49,8 +50,8 @@ describe provider_class do
     provider.exists?
   end
 
-  it 'should be an instance of the provider Ruby' do
-    expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_logical_interconnect).provider(:oneview_logical_interconnect)
+  it 'should be an instance of the provider c7000' do
+    expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_logical_interconnect).provider(:c7000)
   end
 
   it 'should find the interconnect' do

--- a/spec/integration/provider/oneview_logical_interconnect_synergy_spec.rb
+++ b/spec/integration/provider/oneview_logical_interconnect_synergy_spec.rb
@@ -1,0 +1,100 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:oneview_logical_interconnect).provider(:synergy)
+
+describe provider_class do
+  let(:resource) do
+    Puppet::Type.type(:oneview_logical_interconnect).new(
+      name: 'Test Logical Interconnect',
+      ensure: 'present',
+      data:
+          {
+            'name' => 'Encl2-my enclosure logical interconnect group',
+            'internalNetworks' => ['NET'],
+            'snmpConfiguration' =>
+              {
+                'enabled' => true
+              },
+            'firmware' =>
+              {
+                'command' => 'Stage',
+                'isoFileName' => 'fake_firmware.iso',
+                'force' => false
+              }
+          },
+      provider: 'synergy'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  before(:each) do
+    provider.exists?
+  end
+
+  it 'should be an instance of the provider synergy' do
+    expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_logical_interconnect).provider(:synergy)
+  end
+
+  it 'should find the interconnect' do
+    expect(provider.found).to be
+  end
+
+  it 'should get the snmp configuration from the logical interconnect' do
+    expect(provider.get_snmp_configuration).to be
+  end
+
+  it 'should get the firmware from the logical interconnect' do
+    expect(provider.get_firmware).to be
+  end
+
+  it 'should get the port monitor from the logical interconnect' do
+    expect(provider.get_port_monitor).to be
+  end
+
+  it 'should get the list of internal networks from the logical interconnect' do
+    expect(provider.get_internal_vlans).to be
+  end
+
+  it 'should get the qos configuration from the logical interconnect' do
+    expect(provider.get_qos_aggregated_configuration).to be
+  end
+
+  it 'should get the logical interconnect compliant' do
+    expect(provider.set_compliance).to be
+  end
+
+  it 'should update the snmp configuration' do
+    expect(provider.set_snmp_configuration).to be
+  end
+
+  it 'should set the firmware configuration' do
+    expect(provider.set_firmware).to be
+  end
+
+  it 'should set the LI configuration' do
+    expect(provider.set_configuration).to be
+  end
+
+  it 'should update the the internal networks' do
+    expect(provider.set_internal_networks).to be
+  end
+end

--- a/spec/unit/provider/oneview_logical_interconnect_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_c7000_spec.rb
@@ -18,56 +18,58 @@ require 'spec_helper'
 require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
-provider_class = Puppet::Type.type(:oneview_logical_interconnect).provider(:oneview_logical_interconnect)
+provider_class = Puppet::Type.type(:oneview_logical_interconnect).provider(:c7000)
 resourcetype = OneviewSDK::LogicalInterconnect
 
 describe provider_class, unit: true do
   include_context 'shared context'
-  context 'given the min parameters' do
-    let(:resource) do
-      Puppet::Type.type(:oneview_logical_interconnect).new(
-        name: 'LI',
-        ensure: 'present',
-        data:
+
+  let(:resource) do
+    Puppet::Type.type(:oneview_logical_interconnect).new(
+      name: 'LI',
+      ensure: 'present',
+      data:
+          {
+            'name' => 'Encl2-my enclosure logical interconnect group',
+            'internalNetworks' => ['NET'],
+            'snmpConfiguration' =>
             {
-              'name' => 'Encl2-my enclosure logical interconnect group',
-              'internalNetworks' => ['NET'],
-              'snmpConfiguration' =>
+              'enabled' => true
+            },
+            'portMonitor' =>
+            {
+              'enablePortMonitor' => false
+            },
+            'telemetryConfiguration' =>
+            {
+              'enableTelemetry' => true
+            },
+            'qosConfiguration' =>
+            {
+              'activeQosConfig' =>
               {
-                'enabled' => true
-              },
-              'portMonitor' =>
-              {
-                'enablePortMonitor' => false
-              },
-              'telemetryConfiguration' =>
-              {
-                'enableTelemetry' => true
-              },
-              'qosConfiguration' =>
-              {
-                'activeQosConfig' =>
-                {
-                  'configType' => 'Passthrough'
-                }
+                'configType' => 'Passthrough'
               }
             }
-      )
-    end
+          },
+      provider: 'c7000'
+    )
+  end
 
-    let(:provider) { resource.provider }
+  let(:provider) { resource.provider }
 
-    let(:instance) { provider.class.instances.first }
+  let(:instance) { provider.class.instances.first }
 
+  context 'given the min parameters' do
     before(:each) do
       test = resourcetype.new(@client, resource['data'])
       allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
-    it 'should be an instance of the provider' do
+    it 'should be an instance of the provider c7000' do
       expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_logical_interconnect)
-        .provider(:oneview_logical_interconnect)
+        .provider(:c7000)
     end
 
     it 'return false when the resource does not exists' do
@@ -142,6 +144,30 @@ describe provider_class, unit: true do
     it 'should be able to set the qos configuration' do
       expect_any_instance_of(resourcetype).to receive(:update_qos_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_qos_aggregated_configuration).to be
+    end
+  end
+
+  context 'given the min parameters' do
+    let(:resource) do
+      Puppet::Type.type(:oneview_logical_interconnect).new(
+        name: 'LI',
+        ensure: 'get_telemetry_configuration',
+        data:
+            {
+              'name' => 'Encl2-my enclosure logical interconnect group'
+            },
+        provider: 'c7000'
+      )
+    end
+
+    before(:each) do
+      test = resourcetype.new(@client, resource['data'])
+      allow(resourcetype).to receive(:find_by).and_return([test])
+      provider.exists?
+    end
+
+    it 'should be able to get the telemetry configuration' do
+      expect(provider.get_telemetry_configuration).to be
     end
   end
 end

--- a/spec/unit/provider/oneview_logical_interconnect_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_synergy_spec.rb
@@ -1,0 +1,173 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+require_relative '../../support/fake_response'
+require_relative '../../shared_context'
+
+provider_class = Puppet::Type.type(:oneview_logical_interconnect).provider(:synergy)
+resourcetype = OneviewSDK::LogicalInterconnect
+
+describe provider_class, unit: true, if: login[:api_version] >= 300 do
+  include_context 'shared context'
+
+  let(:resource) do
+    Puppet::Type.type(:oneview_logical_interconnect).new(
+      name: 'LI',
+      ensure: 'present',
+      data:
+          {
+            'name' => 'Encl2-my enclosure logical interconnect group',
+            'internalNetworks' => ['NET'],
+            'snmpConfiguration' =>
+            {
+              'enabled' => true
+            },
+            'portMonitor' =>
+            {
+              'enablePortMonitor' => false
+            },
+            'telemetryConfiguration' =>
+            {
+              'enableTelemetry' => true
+            },
+            'qosConfiguration' =>
+            {
+              'activeQosConfig' =>
+              {
+                'configType' => 'Passthrough'
+              }
+            }
+          },
+      provider: 'synergy'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  context 'given the min parameters' do
+    before(:each) do
+      test = resourcetype.new(@client, resource['data'])
+      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      provider.exists?
+    end
+
+    it 'should be an instance of the provider synergy' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_logical_interconnect)
+        .provider(:synergy)
+    end
+
+    it 'return false when the resource does not exists' do
+      allow(resourcetype).to receive(:find_by).and_return([])
+      expect(provider.exists?).to eq(false)
+    end
+
+    it 'should find the resource' do
+      expect(provider.found).to be
+    end
+
+    it 'should be able to get the qos configuration' do
+      allow_any_instance_of(resourcetype).to receive(:get_qos_aggregated_configuration).and_return('Test')
+      expect(provider.get_qos_aggregated_configuration).to be
+    end
+
+    it 'should be able to get the port monitor' do
+      allow_any_instance_of(resourcetype).to receive(:get_port_monitor).and_return('Test')
+      expect(provider.get_port_monitor).to be
+    end
+
+    it 'should be able to get the firmware' do
+      allow_any_instance_of(resourcetype).to receive(:get_firmware).and_return('Test')
+      expect(provider.get_firmware).to be
+    end
+
+    it 'should be able to get the vlans' do
+      test_network = OneviewSDK::EthernetNetwork.new(@client, name: 'NET')
+      allow(OneviewSDK::EthernetNetwork).to receive(:find_by).with(anything, name: 'NET').and_return([test_network])
+      allow_any_instance_of(resourcetype).to receive(:list_vlan_networks).and_return([test_network])
+      expect(provider.get_internal_vlans).to be
+    end
+
+    it 'should be able to get the snmp configuration' do
+      allow_any_instance_of(resourcetype).to receive(:get_snmp_configuration).and_return('Test')
+      expect(provider.get_snmp_configuration).to be
+    end
+
+    it 'should be able to add an internal network' do
+      test_network = OneviewSDK::EthernetNetwork.new(@client, name: 'NET')
+      allow(OneviewSDK::EthernetNetwork).to receive(:find_by).with(anything, name: 'NET').and_return([test_network])
+      expect_any_instance_of(resourcetype).to receive(:update_internal_networks)
+        .with(test_network).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect(provider.set_internal_networks).to be
+    end
+
+    it 'should be able to set the compliance' do
+      expect_any_instance_of(resourcetype).to receive(:compliance).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect(provider.set_compliance).to be
+    end
+
+    it 'should be able to update the snmp configuration' do
+      expect_any_instance_of(resourcetype).to receive(:update_snmp_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect(provider.set_snmp_configuration).to be
+    end
+
+    it 'should be able to update the port monitor' do
+      expect_any_instance_of(resourcetype).to receive(:update_port_monitor).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect(provider.set_port_monitor).to be
+    end
+
+    it 'should be able to set the configuration' do
+      expect_any_instance_of(resourcetype).to receive(:configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect(provider.set_configuration).to be
+    end
+
+    it 'should be able to set the telemetry configuration' do
+      expect_any_instance_of(resourcetype).to receive(:update_telemetry_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect(provider.set_telemetry_configuration).to be
+    end
+
+    it 'should be able to set the qos configuration' do
+      expect_any_instance_of(resourcetype).to receive(:update_qos_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect(provider.set_qos_aggregated_configuration).to be
+    end
+  end
+
+  context 'given the min parameters' do
+    let(:resource) do
+      Puppet::Type.type(:oneview_logical_interconnect).new(
+        name: 'LI',
+        ensure: 'get_telemetry_configuration',
+        data:
+            {
+              'name' => 'Encl2-my enclosure logical interconnect group'
+            },
+        provider: 'synergy'
+      )
+    end
+
+    before(:each) do
+      test = resourcetype.new(@client, resource['data'])
+      allow(resourcetype).to receive(:find_by).and_return([test])
+      provider.exists?
+    end
+
+    it 'should be able to get the telemetry configuration' do
+      expect(provider.get_telemetry_configuration).to be
+    end
+  end
+end


### PR DESCRIPTION
### Description
Extends support for API300 on Synergy and C7000 for the Oneview_logical_interconnect resource

### Issues Resolved
#16 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
