### PR TITLE
Oneview_logical_switch_group API300 Support

### DIFF
--- a/examples/logical_switch_group.pp
+++ b/examples/logical_switch_group.pp
@@ -14,6 +14,8 @@
 # limitations under the License.
 ################################################################################
 
+# This resource is NOT supported if using the Synergy Hardware Variant
+
 oneview_logical_switch_group{'Logical Switch Group Create':
   ensure => 'present',
   data   =>
@@ -21,7 +23,6 @@ oneview_logical_switch_group{'Logical Switch Group Create':
       name     => 'OneViewSDK Test Logical Switch Group',
       category => 'logical-switch-groups',
       state    => 'Active',
-      type     => 'logical-switch-group',
       switches =>
       {
         number_of_switches => '2',

--- a/lib/puppet/provider/oneview_logical_switch_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_switch_group/c7000.rb
@@ -14,19 +14,14 @@
 # limitations under the License.
 ################################################################################
 
-require_relative '../login'
-require_relative '../common'
-require 'oneview-sdk'
+require_relative '../oneview_resource'
 
-Puppet::Type.type(:oneview_logical_switch_group).provide(:oneview_logical_switch_group) do
+Puppet::Type::Oneview_logical_switch_group.provide :c7000, parent: Puppet::OneviewResource do
+  desc 'Provider for OneView Fiber Channel Networks using the C7000 variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'C7000'
+
   mk_resource_methods
-
-  def initialize(*args)
-    super(*args)
-    @client = OneviewSDK::Client.new(login)
-    @resourcetype = OneviewSDK::LogicalSwitchGroup
-    @data = {}
-  end
 
   def exists?
     @data = data_parse
@@ -43,13 +38,5 @@ Puppet::Type.type(:oneview_logical_switch_group).provide(:oneview_logical_switch
     @data['new_name'] = new_name if new_name
     return true if resource_update(@data, @resourcetype)
     lsg.create
-  end
-
-  def destroy
-    get_single_resource_instance.delete
-  end
-
-  def found
-    find_resources
   end
 end

--- a/lib/puppet/provider/oneview_logical_switch_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_switch_group/c7000.rb
@@ -17,7 +17,7 @@
 require_relative '../oneview_resource'
 
 Puppet::Type::Oneview_logical_switch_group.provide :c7000, parent: Puppet::OneviewResource do
-  desc 'Provider for OneView Fiber Channel Networks using the C7000 variant of the OneView API'
+  desc 'Provider for OneView Logical Switch Groups using the C7000 variant of the OneView API'
 
   confine true: login[:hardware_variant] == 'C7000'
 

--- a/spec/integration/provider/oneview_logical_switch_group_c7000_spec.rb
+++ b/spec/integration/provider/oneview_logical_switch_group_c7000_spec.rb
@@ -15,7 +15,7 @@
 ################################################################################
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:oneview_logical_switch_group).provider(:oneview_logical_switch_group)
+provider_class = Puppet::Type.type(:oneview_logical_switch_group).provider(:c7000)
 
 describe provider_class do
   let(:resource) do
@@ -33,7 +33,8 @@ describe provider_class do
               'number_of_switches' => '1',
               'type' => 'Cisco Nexus 50xx'
             }
-          }
+          },
+      provider: 'c7000'
     )
   end
 
@@ -45,8 +46,8 @@ describe provider_class do
 
   let(:instance) { provider.class.instances.first }
 
-  it 'should be an instance of the provider Ruby' do
-    expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_logical_switch_group).provider(:oneview_logical_switch_group)
+  it 'should be an instance of the provider c7000' do
+    expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_logical_switch_group).provider(:c7000)
   end
 
   it 'should return the LSG does not exist' do

--- a/spec/unit/provider/oneview_logical_switch_group_spec.rb
+++ b/spec/unit/provider/oneview_logical_switch_group_spec.rb
@@ -19,7 +19,13 @@ require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_logical_switch_group).provider(:oneview_logical_switch_group)
-resourcetype = OneviewSDK::LogicalSwitchGroup
+api_version = login[:api_version] || 200
+@resource_name = 'LogicalSwitchGroup'
+resourcetype ||= if api_version == 200
+                   Object.const_get("OneviewSDK::API#{api_version}::#{@resource_name}")
+                 else
+                   Object.const_get("OneviewSDK::API#{api_version}::C7000::#{@resource_name}")
+                 end
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -33,13 +39,13 @@ describe provider_class, unit: true do
               'name' => 'OneViewSDK Test Logical Switch Group',
               'category' => 'logical-switch-groups',
               'state' => 'Active',
-              'type' => 'logical-switch-group',
               'switches' =>
               {
                 'number_of_switches' => '1',
                 'type' => 'Cisco Nexus 50xx'
               }
-            }
+            },
+        provider: 'c7000'
       )
     end
 
@@ -47,42 +53,32 @@ describe provider_class, unit: true do
 
     let(:instance) { provider.class.instances.first }
 
-    it 'should be an instance of the provider' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_logical_switch_group).provider(:oneview_logical_switch_group)
+    let(:test) { resourcetype.new(@client, resource['data']) }
+
+    before(:each) do
+      allow(resourcetype).to receive(:find_by).and_return([test])
+      provider.exists?
     end
 
-    it 'return false when the resource does not exists' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      expect(provider.exists?).to eq(false)
+    it 'should be an instance of the c7000' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_logical_switch_group).provider(:c7000)
     end
 
     it 'should be able to find the connection template' do
-      test = resourcetype.new(@client, name: resource['data']['name'])
-      allow(resourcetype).to receive(:find_by).and_return([test])
-      expect(provider.exists?).to eq(true)
       expect(provider.found).to be
     end
 
     it 'should be able to delete the resource' do
-      resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
-      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
-      provider.exists?
+      allow_any_instance_of(resourcetype).to receive(:delete).and_return(true)
       expect(provider.destroy).to be
     end
 
     it 'should be able to find the resource' do
-      test = resourcetype.new(@client, name: resource['data']['name'])
-      allow(resourcetype).to receive(:find_by).and_return([test])
-      expect(provider.exists?).to eq(true)
       expect(provider.found).to be
     end
 
-    it 'runs through the create method' do
+    it 'successfully runs through the create method' do
       allow(resourcetype).to receive(:find_by).and_return([])
-      test = resourcetype.new(@client, resource['data'])
       allow_any_instance_of(resourcetype).to receive(:set_grouping_parameters).with(1, 'Cisco Nexus 50xx').and_return(test)
       allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
       provider.exists?


### PR DESCRIPTION
### Description
Extends Oneview_logical_switch_group support to API300 C7000

### Issues Resolved
#19 

### Check List
- [X] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
