### PR TITLE
Extends support of Oneview_uplink_set for API300

### DIFF
--- a/lib/puppet/provider/oneview_uplink_set/synergy.rb
+++ b/lib/puppet/provider/oneview_uplink_set/synergy.rb
@@ -1,0 +1,21 @@
+################################################################################
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+Puppet::Type.type(:oneview_uplink_set).provide :synergy, parent: :c7000 do
+  desc 'Provider for OneView Uplink Sets using the Synergy variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'Synergy'
+end

--- a/spec/integration/provider/oneview_uplink_set_c7000_spec.rb
+++ b/spec/integration/provider/oneview_uplink_set_c7000_spec.rb
@@ -1,0 +1,97 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+require File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/puppet/provider/', 'login'))
+
+provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:c7000)
+logical_interconnect_name = login[:logical_interconnect_name] || 'Encl1-Test Oneview'
+
+describe provider_class do
+  let(:resource) do
+    Puppet::Type.type(:oneview_uplink_set).new(
+      name: 'Enclosure',
+      ensure: 'present',
+      data:
+          {
+            'name' => 'Puppet Uplink Set'
+          },
+      provider: 'c7000'
+    )
+  end
+
+  before(:each) do
+    provider.exists?
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  context 'given the minimum parameters' do
+    it 'should be an instance of the provider C7000' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_uplink_set).provider(:c7000)
+    end
+
+    it 'exists? should not find the uplink set' do
+      expect(provider.exists?).not_to be
+    end
+
+    it 'should return that the uplink set was not found' do
+      provider.exists?
+      expect { provider.found }.to raise_error(/No UplinkSet with the specified data were found on the Oneview Appliance/)
+    end
+  end
+
+  context 'given the create parameters' do
+    let(:resource) do
+      Puppet::Type.type(:oneview_uplink_set).new(
+        name: 'Enclosure',
+        ensure: 'present',
+        data:
+            {
+              'nativeNetworkUri' => 'nil',
+              'reachability' => 'Reachable',
+              'logicalInterconnectUri' => logical_interconnect_name,
+              'manualLoginRedistributionState' => 'NotSupported',
+              'connectionMode' => 'Auto',
+              'lacpTimer' => 'Short',
+              'networkType' => 'Ethernet',
+              'ethernetNetworkType' => 'Tagged',
+              'description' => 'nil',
+              'name' => 'Puppet Uplink Set'
+            },
+        provider: 'c7000'
+      )
+    end
+    it 'should create the uplink set' do
+      expect(provider.create).to be
+    end
+  end
+
+  context 'given the uplink set was created' do
+    it 'exists? should find the uplink set' do
+      expect(provider.exists?).to be
+    end
+    it 'should return that the uplink set was found' do
+      expect(provider.found).to be
+    end
+
+    it 'should drop the uplink set' do
+      expect(provider.destroy).to be
+    end
+  end
+end

--- a/spec/integration/provider/oneview_uplink_set_synergy_spec.rb
+++ b/spec/integration/provider/oneview_uplink_set_synergy_spec.rb
@@ -18,9 +18,10 @@ require 'spec_helper'
 require File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/puppet/provider/', 'login'))
 
 provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:synergy)
+api_version = login[:api_version] || 200
 logical_interconnect_name = login[:logical_interconnect_name] || 'Encl1-Test Oneview'
 
-describe provider_class do
+describe provider_class, if: api_version >= 300 do
   let(:resource) do
     Puppet::Type.type(:oneview_uplink_set).new(
       name: 'Enclosure',

--- a/spec/integration/provider/oneview_uplink_set_synergy_spec.rb
+++ b/spec/integration/provider/oneview_uplink_set_synergy_spec.rb
@@ -1,5 +1,5 @@
 ################################################################################
-# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 require 'spec_helper'
 require File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/puppet/provider/', 'login'))
 
-provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:oneview_uplink_set)
+provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:synergy)
 logical_interconnect_name = login[:logical_interconnect_name] || 'Encl1-Test Oneview'
 
 describe provider_class do
@@ -28,7 +28,8 @@ describe provider_class do
       data:
           {
             'name' => 'Puppet Uplink Set'
-          }
+          },
+      provider: 'synergy'
     )
   end
 
@@ -41,8 +42,8 @@ describe provider_class do
   let(:instance) { provider.class.instances.first }
 
   context 'given the minimum parameters' do
-    it 'should be an instance of the provider oneview_uplink_set' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_uplink_set).provider(:oneview_uplink_set)
+    it 'should be an instance of the provider synergy' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_uplink_set).provider(:synergy)
     end
 
     it 'exists? should not find the uplink set' do
@@ -72,7 +73,8 @@ describe provider_class do
               'ethernetNetworkType' => 'Tagged',
               'description' => 'nil',
               'name' => 'Puppet Uplink Set'
-            }
+            },
+        provider: 'synergy'
       )
     end
     it 'should create the uplink set' do
@@ -80,7 +82,7 @@ describe provider_class do
     end
   end
 
-  context 'given the minimum parameters' do
+  context 'given the uplink set was created' do
     it 'exists? should find the uplink set' do
       expect(provider.exists?).to be
     end

--- a/spec/unit/provider/oneview_uplink_set_c7000_spec.rb
+++ b/spec/unit/provider/oneview_uplink_set_c7000_spec.rb
@@ -19,7 +19,13 @@ require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:c7000)
-resourcetype = OneviewSDK::UplinkSet
+api_version = login[:api_version] || 200
+resource_name = 'UplinkSet'
+resourcetype = if api_version == 200
+                 Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
+               else
+                 Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
+               end
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_uplink_set_c7000_spec.rb
+++ b/spec/unit/provider/oneview_uplink_set_c7000_spec.rb
@@ -1,0 +1,183 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+require_relative '../../support/fake_response'
+require_relative '../../shared_context'
+
+provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:c7000)
+resourcetype = OneviewSDK::UplinkSet
+
+describe provider_class, unit: true do
+  include_context 'shared context'
+
+  let(:resource) do
+    Puppet::Type.type(:oneview_uplink_set).new(
+      name: 'uplink_set_1',
+      ensure: 'found',
+      provider: 'c7000'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  context 'given the Creation parameters' do
+    let(:resource) do
+      Puppet::Type.type(:oneview_uplink_set).new(
+        name: 'uplink_set_1',
+        ensure: 'present',
+        data:
+            {
+              'nativeNetworkUri'               => 'nil',
+              'reachability'                   => 'Reachable',
+              'manualLoginRedistributionState' => 'NotSupported',
+              'connectionMode'                 => 'Auto',
+              'lacpTimer'                      => 'Short',
+              'networkType'                    => 'Ethernet',
+              'ethernetNetworkType'            => 'Tagged',
+              'description'                    => 'nil',
+              'name'                           => 'Puppet Uplink Set',
+              'portConfigInfos' =>
+              [
+                '/rest/interconnects/8e48bbd0-b651-46e1-afdf-334332a3a233',
+                'Auto',
+                [{ value: 1, type: 'Bay' }, { value: '/rest/enclosures/09SGH100X6J1', type: 'Enclosure' }, { value: 'X1', type: 'Port' }]
+              ],
+              'networkUris' => [
+                '/rest/fake/1', '/rest/fake/2'
+              ],
+              'logicalInterconnectUri' => '/rest/fake/3'
+            },
+        provider: 'c7000'
+      )
+    end
+
+    it 'should be an instance of the provider c7000' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_uplink_set).provider(:c7000)
+    end
+
+    it 'should return false if resource does not exist' do
+      allow(resourcetype).to receive(:find_by).and_return([])
+      expect(provider.exists?).to eq(false)
+      expect { provider.found }.to raise_error(/No UplinkSet with the specified data were found on the Oneview Appliance/)
+    end
+
+    it 'should return true if resource exists / is found' do
+      test = resourcetype.new(@client, resource['data'])
+      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      expect(provider.exists?).to be
+      expect(provider.found).to eq(true)
+    end
+
+    it 'deletes the resource' do
+      resource['data']['uri'] = '/rest/fake'
+      test = OneviewSDK::UplinkSet.new(@client, resource['data'])
+      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
+      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      provider.exists?
+      expect(provider.destroy).to be
+    end
+  end
+
+  context 'When using FC Network ' do
+    let(:resource) do
+      Puppet::Type.type(:oneview_uplink_set).new(
+        name: 'uplink_set_1',
+        ensure: 'present',
+        data:
+            {
+              'nativeNetworkUri'               => 'nil',
+              'reachability'                   => 'Reachable',
+              'manualLoginRedistributionState' => 'NotSupported',
+              'connectionMode'                 => 'Auto',
+              'lacpTimer'                      => 'Short',
+              'networkType'                    => 'Ethernet',
+              'ethernetNetworkType'            => 'Tagged',
+              'description'                    => 'nil',
+              'name'                           => 'Puppet Uplink Set',
+              'portConfigInfos' =>
+              [
+                '/rest/interconnects/8e48bbd0-b651-46e1-afdf-334332a3a233',
+                'Auto',
+                [{ value: 1, type: 'Bay' }, { value: '/rest/enclosures/09SGH100X6J1', type: 'Enclosure' }, { value: 'X1', type: 'Port' }]
+              ],
+              'fcNetworkUris' => [
+                '/rest/fake/1', '/rest/fake/2'
+              ],
+              'logicalInterconnectUri' => '/rest/fake/3'
+            },
+        provider: 'c7000'
+      )
+    end
+
+    it 'runs through the create method' do
+      allow(resourcetype).to receive(:find_by).and_return([])
+      fc_network = OneviewSDK::FCNetwork.new(@client, name: 'Puppet Test FCNetwork', uri: '/rest/fc-networks/fake')
+      logint = OneviewSDK::LogicalInterconnect.new(@client, name: 'Encl1-Test Oneview', uri: '/rest/logical-interconnects/fake')
+      allow(OneviewSDK::FCNetwork).to receive(:find_by).and_return([fc_network])
+      allow(OneviewSDK::LogicalInterconnect).to receive(:find_by).and_return([logint])
+      allow_any_instance_of(resourcetype).to receive(:create).and_return(OneviewSDK::UplinkSet.new(@client, resource['data']))
+      provider.exists?
+      expect(provider.create).to eq(true)
+    end
+  end
+
+  context 'When using FCoE Network ' do
+    let(:resource) do
+      Puppet::Type.type(:oneview_uplink_set).new(
+        name: 'uplink_set_1',
+        ensure: 'present',
+        data:
+            {
+              'nativeNetworkUri'               => 'nil',
+              'reachability'                   => 'Reachable',
+              'manualLoginRedistributionState' => 'NotSupported',
+              'connectionMode'                 => 'Auto',
+              'lacpTimer'                      => 'Short',
+              'networkType'                    => 'Ethernet',
+              'ethernetNetworkType'            => 'Tagged',
+              'description'                    => 'nil',
+              'name'                           => 'Puppet Uplink Set',
+              'portConfigInfos' =>
+              [
+                '/rest/interconnects/8e48bbd0-b651-46e1-afdf-334332a3a233',
+                'Auto',
+                [{ value: 1, type: 'Bay' }, { value: '/rest/enclosures/09SGH100X6J1', type: 'Enclosure' }, { value: 'X1', type: 'Port' }]
+              ],
+              'fcoeNetworkUris' => [
+                '/rest/fake/1', '/rest/fake/2'
+              ],
+              'logicalInterconnectUri' => '/rest/fake/3'
+            },
+        provider: 'c7000'
+      )
+    end
+
+    it 'runs through the create method' do
+      allow(resourcetype).to receive(:find_by).and_return([])
+      fcoe_network = OneviewSDK::FCoENetwork.new(@client, name: 'Puppet Test FCoENetwork', uri: '/rest/fcoe-networks/fake')
+      logint = OneviewSDK::LogicalInterconnect.new(@client, name: 'Encl1-Test Oneview', uri: '/rest/logical-interconnects/fake')
+      allow(OneviewSDK::FCoENetwork).to receive(:find_by).and_return([fcoe_network])
+      allow(OneviewSDK::LogicalInterconnect).to receive(:find_by).and_return([logint])
+      allow_any_instance_of(resourcetype).to receive(:create).and_return(OneviewSDK::UplinkSet.new(@client, resource['data']))
+      provider.exists?
+      expect(provider.create).to eq(true)
+    end
+  end
+end

--- a/spec/unit/provider/oneview_uplink_set_synergy_spec.rb
+++ b/spec/unit/provider/oneview_uplink_set_synergy_spec.rb
@@ -19,9 +19,11 @@ require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:synergy)
-resourcetype = OneviewSDK::UplinkSet
+api_version = login[:api_version] || 200
+resource_name = 'UplinkSet'
+resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
 
-describe provider_class, unit: true do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   let(:resource) do

--- a/spec/unit/provider/oneview_uplink_set_synergy_spec.rb
+++ b/spec/unit/provider/oneview_uplink_set_synergy_spec.rb
@@ -1,5 +1,5 @@
 ################################################################################
-# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.
@@ -18,18 +18,17 @@ require 'spec_helper'
 require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
-provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:oneview_uplink_set)
+provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:synergy)
 resourcetype = OneviewSDK::UplinkSet
 
 describe provider_class, unit: true do
   include_context 'shared context'
 
-  @resourcetype = OneviewSDK::UplinkSet
-
   let(:resource) do
     Puppet::Type.type(:oneview_uplink_set).new(
       name: 'uplink_set_1',
-      ensure: 'found'
+      ensure: 'found',
+      provider: 'synergy'
     )
   end
 
@@ -63,23 +62,24 @@ describe provider_class, unit: true do
                 '/rest/fake/1', '/rest/fake/2'
               ],
               'logicalInterconnectUri' => '/rest/fake/3'
-            }
+            },
+        provider: 'synergy'
       )
     end
 
-    it 'should be an instance of the provider oneview_uplink_set' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_uplink_set).provider(:oneview_uplink_set)
+    it 'should be an instance of the provider synergy of oneview_uplink_set' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_uplink_set).provider(:synergy)
     end
 
     it 'should return false if resource does not exist' do
-      allow(OneviewSDK::UplinkSet).to receive(:find_by).and_return([])
+      allow(resourcetype).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
       expect { provider.found }.to raise_error(/No UplinkSet with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should return true if resource exists / is found' do
       test = OneviewSDK::UplinkSet.new(@client, resource['data'])
-      allow(OneviewSDK::UplinkSet).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
       expect(provider.found).to eq(true)
     end
@@ -87,8 +87,8 @@ describe provider_class, unit: true do
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
       test = OneviewSDK::UplinkSet.new(@client, resource['data'])
-      allow(OneviewSDK::UplinkSet).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(OneviewSDK::UplinkSet).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
+      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be
@@ -121,12 +121,13 @@ describe provider_class, unit: true do
                 '/rest/fake/1', '/rest/fake/2'
               ],
               'logicalInterconnectUri' => '/rest/fake/3'
-            }
+            },
+        provider: 'synergy'
       )
     end
 
     it 'runs through the create method' do
-      allow(OneviewSDK::UplinkSet).to receive(:find_by).and_return([])
+      allow(resourcetype).to receive(:find_by).and_return([])
       fc_network = OneviewSDK::FCNetwork.new(@client, name: 'Puppet Test FCNetwork', uri: '/rest/fc-networks/fake')
       logint = OneviewSDK::LogicalInterconnect.new(@client, name: 'Encl1-Test Oneview', uri: '/rest/logical-interconnects/fake')
       allow(OneviewSDK::FCNetwork).to receive(:find_by).and_return([fc_network])
@@ -163,12 +164,13 @@ describe provider_class, unit: true do
                 '/rest/fake/1', '/rest/fake/2'
               ],
               'logicalInterconnectUri' => '/rest/fake/3'
-            }
+            },
+        provider: 'synergy'
       )
     end
 
     it 'runs through the create method' do
-      allow(OneviewSDK::UplinkSet).to receive(:find_by).and_return([])
+      allow(resourcetype).to receive(:find_by).and_return([])
       fcoe_network = OneviewSDK::FCoENetwork.new(@client, name: 'Puppet Test FCoENetwork', uri: '/rest/fcoe-networks/fake')
       logint = OneviewSDK::LogicalInterconnect.new(@client, name: 'Encl1-Test Oneview', uri: '/rest/logical-interconnects/fake')
       allow(OneviewSDK::FCoENetwork).to receive(:find_by).and_return([fcoe_network])


### PR DESCRIPTION
### Description
Use Oneview_uplink_set with API 300 on the Synergy and C7000 hardware variants

### Issues Resolved
https://github.com/HewlettPackard/oneview-puppet/issues/32

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
