### PR TITLE
Adding support to new resource SAS Logical Interconnect Group

### DIFF
--- a/examples/sas_logical_interconnect_group.pp
+++ b/examples/sas_logical_interconnect_group.pp
@@ -1,0 +1,56 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# The Interconnects and Uplink Sets can also be declared as follows:
+oneview_sas_logical_interconnect_group{'Puppet SAS LIG':
+  ensure => 'present',
+  data   => {
+    name          => 'Puppet SAS LIG',
+    interconnects =>
+    [
+      {
+        bay  => 1,
+        type => 'Synergy 12Gb SAS Connection Module'
+      },
+      {
+        bay  => 4,
+        type => 'Synergy 12Gb SAS Connection Module'
+      },
+    ]
+  }
+}
+
+oneview_sas_logical_interconnect_group{'Logical Interconnect Group Edit':
+  ensure  => 'present',
+  require => Oneview_sas_logical_interconnect_group['Puppet SAS LIG'],
+  data    => {
+    name     => 'Puppet SAS LIG',
+    new_name => 'Edited LIG'
+  }
+}
+
+oneview_sas_logical_interconnect_group{'Logical Interconnect Group Found':
+  ensure  => 'found',
+  require => Oneview_sas_logical_interconnect_group['Logical Interconnect Group Edit'],
+}
+
+oneview_sas_logical_interconnect_group{'Logical Interconnect Group Destroy':
+  ensure  => 'absent',
+  require => Oneview_sas_logical_interconnect_group['Puppet SAS LIG'],
+  data    => {
+    name => 'Edited LIG'
+  }
+}

--- a/lib/puppet/provider/oneview_sas_logical_interconnect_group/synergy.rb
+++ b/lib/puppet/provider/oneview_sas_logical_interconnect_group/synergy.rb
@@ -17,7 +17,7 @@
 require_relative '../oneview_resource'
 
 Puppet::Type::Oneview_sas_logical_interconnect_group.provide :synergy, parent: Puppet::OneviewResource do
-  desc 'Provider for OneView SAS Logical Enclosures using the Synergy variant of the OneView API'
+  desc 'Provider for OneView SAS Logical Interconnect Groups using the Synergy variant of the OneView API'
 
   confine true: login[:hardware_variant] == 'Synergy'
 

--- a/lib/puppet/provider/oneview_sas_logical_interconnect_group/synergy.rb
+++ b/lib/puppet/provider/oneview_sas_logical_interconnect_group/synergy.rb
@@ -1,0 +1,56 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require_relative '../oneview_resource'
+
+Puppet::Type::Oneview_sas_logical_interconnect_group.provide :synergy, parent: Puppet::OneviewResource do
+  desc 'Provider for OneView SAS Logical Enclosures using the Synergy variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'Synergy'
+
+  mk_resource_methods
+
+  def resource_name
+    'SASLogicalInterconnectGroup'
+  end
+
+  def self.resource_name
+    'SASLogicalInterconnectGroup'
+  end
+
+  def exists?
+    super
+    @interconnects = @data.delete('interconnects')
+    !@resourcetype.find_by(@client, @data).empty?
+  end
+
+  def create
+    new_name = @data.delete('new_name')
+    lig = @resourcetype.new(@client, @data)
+    add_interconnects(lig) if @interconnects
+    @data['new_name'] = new_name if new_name
+    return true if resource_update(@data, @resourcetype)
+    lig.create
+    @property_hash[:data] = lig.data
+    @property_hash[:ensure] = :present
+  end
+
+  def add_interconnects(lig)
+    @interconnects.each do |item|
+      lig.add_interconnect(item['bay'].to_i, item['type'])
+    end
+  end
+end

--- a/lib/puppet/type/oneview_sas_logical_interconnect_group.rb
+++ b/lib/puppet/type/oneview_sas_logical_interconnect_group.rb
@@ -1,0 +1,40 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+Puppet::Type.newtype(:oneview_sas_logical_interconnect_group) do
+  desc "Oneview's SAS Logical Interconnect Group"
+
+  #:nocov:
+  ensurable do
+    defaultvalues
+
+    newvalue(:found) do
+      provider.found
+    end
+  end
+  #:nocov:
+
+  newparam(:name, namevar: true) do
+    desc 'SAS Logical Interconnect Group process name'
+  end
+
+  newparam(:data) do
+    desc 'SAS Logical Interconnect Group data hash containing all specifications for the resource'
+    validate do |value|
+      raise('Inserted value for data is not valid') unless value.class == Hash
+    end
+  end
+end

--- a/spec/integration/provider/oneview_sas_logical_interconnect_group_spec.rb
+++ b/spec/integration/provider/oneview_sas_logical_interconnect_group_spec.rb
@@ -1,0 +1,78 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:oneview_sas_logical_interconnect_group).provider(:synergy)
+
+describe provider_class do
+  let(:resource) do
+    Puppet::Type.type(:oneview_sas_logical_interconnect_group).new(
+      name: 'Test LIG',
+      ensure: 'present',
+      data:
+       {
+         'name'          => 'Puppet Integration SAS LIG',
+         'interconnects' =>
+        [
+          {
+            'bay'  => 1,
+            'type' => 'Synergy 12Gb SAS Connection Module'
+          },
+          {
+            'bay'  => 4,
+            'type' => 'Synergy 12Gb SAS Connection Module'
+          }
+        ]
+       },
+      provider: 'synergy'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  before(:each) do
+    provider.exists?
+  end
+
+  it 'should be an instance of the provider synergy' do
+    expect(provider)
+      .to be_an_instance_of Puppet::Type.type(:oneview_sas_logical_interconnect_group).provider(:synergy)
+  end
+
+  context 'given the minimum parameters' do
+    it 'should create the sas logical interconnect group' do
+      expect(provider.create).to be
+    end
+
+    it 'should update the sas logical interconnect group' do
+      resource['data']['new_name'] = 'test'
+      expect(provider.create).to be
+      resource['data']['new_name'] = 'Puppet Integration SAS LIG'
+      expect(provider.create).to be
+    end
+
+    it 'should be able to find the sas logical interconnect group' do
+      expect(provider.found).to be
+    end
+
+    it 'should be able to delete the sas logical interconnect group' do
+      expect(provider.destroy).to be
+    end
+  end
+end

--- a/spec/unit/provider/oneview_sas_logical_interconnect_group_spec.rb
+++ b/spec/unit/provider/oneview_sas_logical_interconnect_group_spec.rb
@@ -1,0 +1,86 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:oneview_sas_logical_interconnect_group).provider(:synergy)
+api_version = login[:api_version] || 300
+resource_name = 'SASLogicalInterconnectGroup'
+resourcetype ||= Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless login[:api_version] == 200
+
+describe provider_class, unit: true, if: login[:api_version] >= 300 do
+  include_context 'shared context'
+
+  let(:resource) do
+    Puppet::Type.type(:oneview_sas_logical_interconnect_group).new(
+      name: 'Test LIG',
+      ensure: 'present',
+      data:
+       {
+         'name'          => 'Puppet Unit SAS LIG',
+         'interconnects' =>
+        [
+          {
+            'bay'  => 1,
+            'type' => 'Synergy 12Gb SAS Connection Module'
+          },
+          {
+            'bay'  => 4,
+            'type' => 'Synergy 12Gb SAS Connection Module'
+          }
+        ]
+       },
+      provider: 'synergy'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  let(:test) { resourcetype.new(@client, resource['data']) }
+
+  context 'given the min parameters' do
+    before(:each) do
+      allow(resourcetype).to receive(:find_by).and_return([test])
+      provider.exists?
+    end
+
+    it 'should be an instance of the provider synergy' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_sas_logical_interconnect_group).provider(:synergy)
+    end
+
+    it 'should be able to run through self.instances' do
+      expect(instance).to be
+    end
+
+    it 'runs through the create method' do
+      allow(resourcetype).to receive(:find_by).and_return([])
+      allow_any_instance_of(resourcetype).to receive(:add_interconnect).and_return('')
+      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      expect(provider.create).to be
+    end
+
+    it 'should be able to find the resource' do
+      expect(provider.found).to be
+    end
+
+    it 'deletes the resource' do
+      expect_any_instance_of(resourcetype).to receive(:delete).and_return(true)
+      expect(provider.destroy).to be
+    end
+  end
+end


### PR DESCRIPTION
### Description
Adds a new type to the Oneview module for managing Oneview SAS Logical Interconnect Groups

### Issues Resolved
#69 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
