### PR TITLE
Oneview_server_profile API300 Support

### DIFF
--- a/examples/server_profile.pp
+++ b/examples/server_profile.pp
@@ -37,29 +37,51 @@ oneview_server_profile{'Server Profile Get Available Targets':
 }
 
 oneview_server_profile{'Server Profile Create':
-  ensure  => 'present',
-  require => Oneview_server_profile['Server Profile Get Available Targets'],
-  data    =>
+  ensure => 'present',
+  data   =>
   {
     name              => 'Test Server Profile',
-    type              => 'ServerProfileV5',
-    serverHardwareUri => '172.18.6.15',
+    serverHardwareUri => '172.18.6.6',
   }
 }
 
 # Optional filters
 oneview_server_profile{'Server Profile Found':
   ensure  => 'found',
-  require => Oneview_server_profile['Server Profile Create'],
-  # data    =>
-  # {
-  #   name => 'Test Server Profile'
-  # }
 }
 
+# This ensure method is only available for Synergy Hardware
+oneview_server_profile{'Server Profile get_sas_logical_jbods':
+  ensure => 'get_sas_logical_jbods',
+  data   =>
+  {
+    name     => 'Test Server Profile',
+  }
+}
+
+# This ensure method is only available for Synergy Hardware
+oneview_server_profile{'Server Profile get_sas_logical_jbod_drives':
+  ensure => 'get_sas_logical_jbod_drives',
+  data   =>
+  {
+    name     => 'Test Server Profile',
+  }
+}
+
+# This ensure method is only available for Synergy Hardware
+oneview_server_profile{'Server Profile get_sas_logical_jbod_attachments':
+  ensure => 'get_sas_logical_jbod_attachments',
+  data   =>
+  {
+    name     => 'Test Server Profile',
+  }
+}
+
+
+# To update/modify the server profile name
 oneview_server_profile{'Server Profile Edit':
   ensure  => 'present',
-  require => Oneview_server_profile['Server Profile Found'],
+  require => Oneview_server_profile['Server Profile Create'],
   data    =>
   {
     name     => 'Test Server Profile',

--- a/lib/puppet/provider/oneview_server_profile/synergy.rb
+++ b/lib/puppet/provider/oneview_server_profile/synergy.rb
@@ -1,0 +1,50 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+Puppet::Type.type(:oneview_server_profile).provide :synergy, parent: :c7000 do
+  desc 'Provider for OneView Server Profiles using the Synergy variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'Synergy'
+
+  # Retrieves all SAS Logical JBOD OR Retrieves a SAS Logical JBOD by name
+  def get_sas_logical_jbods
+    Puppet.notice("\n\nLogical JBOD Attachments\n")
+    if @data['name']
+      pretty @resourcetype.get_sas_logical_jbod(@client, @data['name'])
+    else
+      pretty @resourcetype.get_sas_logical_jbods(@client)
+    end
+    true
+  end
+
+  # Retrieves drives by SAS Logical JBOD name
+  def get_sas_logical_jbod_drives
+    Puppet.notice("\n\nLogical JBOD Drives\n")
+    pretty @resourcetype.get_sas_logical_jbod_drives(@client, @data['name'])
+    true
+  end
+
+  # Retrieves all SAS Logical JBOD Attachments OR a SAS Logical JBOD Attachment specified in data['name']
+  def get_sas_logical_jbod_attachments
+    Puppet.notice("\n\nLogical JBOD Attachments\n")
+    if @data['name']
+      pretty @resourcetype.get_sas_logical_jbod_attachment(@client, @data['name'])
+    else
+      pretty @resourcetype.get_sas_logical_jbod_attachments(@client)
+    end
+    true
+  end
+end

--- a/lib/puppet/type/oneview_server_profile.rb
+++ b/lib/puppet/type/oneview_server_profile.rb
@@ -66,6 +66,18 @@ Puppet::Type.newtype(:oneview_server_profile) do
     newvalue(:get_transformation) do
       provider.get_transformation
     end
+
+    newvalue(:get_sas_logical_jbods) do
+      provider.get_sas_logical_jbods
+    end
+
+    newvalue(:get_sas_logical_jbod_drives) do
+      provider.get_sas_logical_jbod_drives
+    end
+
+    newvalue(:get_sas_logical_jbod_attachments) do
+      provider.get_sas_logical_jbod_attachments
+    end
   end
   #:nocov:
 

--- a/spec/integration/provider/oneview_server_profile_c7000_spec.rb
+++ b/spec/integration/provider/oneview_server_profile_c7000_spec.rb
@@ -1,0 +1,113 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:oneview_server_profile).provider(:c7000)
+
+describe provider_class do
+  let(:resource) do
+    Puppet::Type.type(:oneview_server_profile).new(
+      name: 'Server Profile',
+      ensure: 'present',
+      data:
+          {
+            'name'              => 'Test Server Profile',
+            'serverHardwareUri' => '172.18.6.6'
+          },
+      provider: 'c7000'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  before(:each) do
+    provider.exists?
+  end
+
+  context 'given the minimum parameters' do
+    it 'should be an instance of the provider c7000' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_server_profile).provider(:c7000)
+    end
+
+    it 'should be able to create the server profile' do
+      expect(provider.create).to be
+    end
+
+    it 'should be able to find the server profile with no filters' do
+      resource['data'] = {}
+      expect(provider.found).to be
+    end
+
+    it 'should be able to get_available_targets' do
+      expect(provider.get_available_targets).to be
+    end
+
+    it 'should be able to get_available_networks' do
+      expect(provider.get_available_networks).to be
+    end
+
+    it 'should be able to get_available_servers' do
+      expect(provider.get_available_servers).to be
+    end
+
+    it 'should be able to get_available_storage_systems' do
+      expect(provider.get_available_storage_systems).to be
+    end
+
+    it 'should be able to get_available_storage_system' do
+      expect(provider.get_available_storage_system).to be
+    end
+
+    it 'should be able to get_profile_ports' do
+      expect(provider.get_profile_ports).to be
+    end
+
+    it 'should be able to get_compliance_preview' do
+      expect(provider.get_compliance_preview).to be
+    end
+
+    it 'should be able to get_messages' do
+      expect(provider.get_messages).to be
+    end
+
+    it 'should be able to get_transformation' do
+      expect(provider.get_transformation).to be
+    end
+
+    it 'should be able to update_from_template' do
+      expect(provider.update_from_template).to be
+    end
+
+    it 'should raise errors for unavailable methods' do
+      expect { provider.get_sas_logical_jbods }.to raise_error(/This ensure method is not available for C7000./)
+      expect { provider.get_sas_logical_jbod_drives }.to raise_error(/This ensure method is not available for C7000./)
+      expect { provider.get_sas_logical_jbod_attachments }.to raise_error(/This ensure method is not available for C7000./)
+    end
+
+    it 'should be able to update the server profile' do
+      resource['data'] = { 'name' => 'Test Server Profile', 'new_name' => 'Edited SP' }
+      expect(provider.create).to be
+    end
+
+    it 'should be able to delete the server profile' do
+      resource['data'] = { 'name' => 'Edited SP' }
+      expect(provider.destroy).to be
+    end
+  end
+end

--- a/spec/integration/provider/oneview_server_profile_synergy_spec.rb
+++ b/spec/integration/provider/oneview_server_profile_synergy_spec.rb
@@ -16,7 +16,7 @@
 
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:oneview_server_profile).provider(:oneview_server_profile)
+provider_class = Puppet::Type.type(:oneview_server_profile).provider(:synergy)
 
 describe provider_class do
   let(:resource) do
@@ -26,9 +26,9 @@ describe provider_class do
       data:
           {
             'name'              => 'Test Server Profile',
-            'type'              => 'ServerProfileV5',
-            'serverHardwareUri' => '172.18.6.15'
-          }
+            'serverHardwareUri' => '172.18.6.6'
+          },
+      provider: 'synergy'
     )
   end
 
@@ -41,8 +41,8 @@ describe provider_class do
   end
 
   context 'given the minimum parameters' do
-    it 'should be an instance of the provider Ruby' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_server_profile).provider(:oneview_server_profile)
+    it 'should be an instance of the provider synergy' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_server_profile).provider(:synergy)
     end
 
     it 'should be able to create the server profile' do
@@ -52,6 +52,58 @@ describe provider_class do
     it 'should be able to find the server profile with no filters' do
       resource['data'] = {}
       expect(provider.found).to be
+    end
+
+    it 'should be able to get_available_targets' do
+      expect(provider.get_available_targets).to be
+    end
+
+    it 'should be able to get_available_networks' do
+      expect(provider.get_available_networks).to be
+    end
+
+    it 'should be able to get_available_servers' do
+      expect(provider.get_available_servers).to be
+    end
+
+    it 'should be able to get_available_storage_systems' do
+      expect(provider.get_available_storage_systems).to be
+    end
+
+    it 'should be able to get_available_storage_system' do
+      expect(provider.get_available_storage_system).to be
+    end
+
+    it 'should be able to get_profile_ports' do
+      expect(provider.get_profile_ports).to be
+    end
+
+    it 'should be able to get_compliance_preview' do
+      expect(provider.get_compliance_preview).to be
+    end
+
+    it 'should be able to get_messages' do
+      expect(provider.get_messages).to be
+    end
+
+    it 'should be able to get_transformation' do
+      expect(provider.get_transformation).to be
+    end
+
+    it 'should be able to update_from_template' do
+      expect(provider.update_from_template).to be
+    end
+
+    it 'should be able to get_sas_logical_jbods' do
+      expect(provider.get_sas_logical_jbods).to be
+    end
+
+    it 'should be able to get_sas_logical_jbod_drives' do
+      expect(provider.get_sas_logical_jbod_drives).to be
+    end
+
+    it 'should be able to get_sas_logical_jbod_attachments' do
+      expect(provider.get_sas_logical_jbod_attachments).to be
     end
 
     it 'should be able to update the server profile' do

--- a/spec/unit/provider/oneview_server_profile_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_synergy_spec.rb
@@ -1,0 +1,175 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:oneview_server_profile).provider(:oneview_server_profile)
+
+describe provider_class, unit: true, if: login[:api_version] >= 300 do
+  api_version = login[:api_version] || 200
+  resource_name = 'ServerProfile'
+  resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+  fake_json_response = File.read('spec/support/fixtures/unit/provider/server_profile.json')
+
+  include_context 'shared context'
+
+  let(:resource) do
+    Puppet::Type.type(:oneview_server_profile).new(
+      name: 'Server Profile',
+      ensure: 'present',
+      data:
+          {
+            'name' => 'Profile',
+            'serverHardwareUri' => '/rest/server-hardware/37333036-3831-584D-5131-303030323037'
+          },
+      provider: 'synergy'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  let(:test) { resourcetype.new(@client, resource['data']) }
+
+  before(:each) do
+    allow(resourcetype).to receive(:find_by).and_return([test])
+    provider.exists?
+  end
+
+  context 'given the minimum parameters before server creation' do
+    it 'should be an instance of the provider synergy' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_server_profile).provider(:synergy)
+    end
+
+    it 'should raise error when server is not found' do
+      allow(resourcetype).to receive(:find_by).and_return([])
+      expect { provider.found }.to raise_error(/No ServerProfile with the specified data were found on the Oneview Appliance/)
+    end
+
+    it 'should be able to create the resource' do
+      allow(resourcetype).to receive(:find_by).and_return([])
+      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      expect(provider.exists?).to eq(false)
+      expect(provider.create).to be
+    end
+
+    it 'should be able to perform the patch update' do
+      allow_any_instance_of(resourcetype).to receive(:update_from_template).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect(provider.update_from_template).to be
+    end
+
+    it 'should be able to get available targets' do
+      allow(resourcetype).to receive(:get_available_targets).with(anything, nil).and_return(fake_json_response)
+      expect(provider.get_available_targets).to be
+    end
+
+    it 'should be able to get the compliance preview' do
+      allow_any_instance_of(resourcetype).to receive(:get_compliance_preview).and_return(fake_json_response)
+      expect(provider.get_compliance_preview).to be
+    end
+
+    it 'should be able to get available networks' do
+      allow_any_instance_of(resourcetype).to receive(:get_available_networks).and_return(fake_json_response)
+      expect(provider.get_available_networks).to be
+    end
+
+    it 'should be able to get the transformation' do
+      allow_any_instance_of(resourcetype).to receive(:get_transformation).and_return(fake_json_response)
+      expect(provider.get_transformation).to be
+    end
+
+    it 'should be able to get messages' do
+      allow_any_instance_of(resourcetype).to receive(:get_messages).and_return(fake_json_response)
+      expect(provider.get_messages).to be
+    end
+
+    it 'should be able to get available servers' do
+      allow(resourcetype).to receive(:get_available_servers).and_return(fake_json_response)
+      expect(provider.get_available_servers).to be
+    end
+
+    it 'should be able to get profile ports' do
+      allow(resourcetype).to receive(:get_profile_ports).and_return(fake_json_response)
+      expect(provider.get_profile_ports).to be
+    end
+
+    it 'should delete the server profile' do
+      expect_any_instance_of(resourcetype).to receive(:delete).and_return(true)
+      expect(provider.destroy).to be
+    end
+
+    it 'should be able to get a sas logical jbod by name' do
+      allow(resourcetype).to receive(:get_sas_logical_jbod).and_return(true)
+      expect(provider.get_sas_logical_jbods).to be
+    end
+
+    it 'should be able to get_sas_logical_jbod_drives for a server profile' do
+      allow(resourcetype).to receive(:get_sas_logical_jbod_drives).and_return(true)
+      expect(provider.get_sas_logical_jbod_drives).to be
+    end
+
+    it 'should be able to get a sas logical jbod attachment by name' do
+      allow(resourcetype).to receive(:get_sas_logical_jbod_attachment).and_return(true)
+      expect(provider.get_sas_logical_jbod_attachments).to be
+    end
+  end
+
+  context 'given the available storage systems query parameters' do
+    let(:resource) do
+      Puppet::Type.type(:oneview_server_profile).new(
+        name: 'Server Profile',
+        ensure: 'get_available_networks',
+        data:
+            {
+              # 'name' => 'Profile',
+              'query_parameters' => {
+                'enclosureGroupUri'     => '/rest/fake',
+                'storageSystemId'       => '/rest/fake',
+                'serverHardwareTypeUri' => '/rest/fake'
+              }
+            },
+        provider: 'synergy'
+      )
+    end
+
+    it 'should successfully get an available storage system' do
+      allow(resourcetype).to receive(:get_available_storage_system).and_return(true)
+      expect(provider.get_available_storage_system).to be
+    end
+
+    it 'should successfully get_available_storage_systems' do
+      allow(resourcetype).to receive(:get_available_storage_systems).and_return(true)
+      expect(provider.get_available_storage_systems).to be
+    end
+
+    it 'should successfully get_available_networks' do
+      allow(resourcetype).to receive(:get_available_networks).and_return(true)
+      provider.exists?
+      expect(provider.get_available_networks).to be
+    end
+
+    it 'should be able to get all sas logical jbod' do
+      allow(resourcetype).to receive(:get_sas_logical_jbods).and_return(true)
+      expect(provider.get_sas_logical_jbods).to be
+    end
+
+    it 'should be able to get all sas logical jbod attachment' do
+      allow(resourcetype).to receive(:get_sas_logical_jbod_attachments).and_return(true)
+      expect(provider.get_sas_logical_jbod_attachments).to be
+    end
+  end
+end


### PR DESCRIPTION
### Description
Extends support of the Oneview_server_profile resource type to API300 on C7000 and Synergy

### Issues Resolved
#26 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
