### PR TITLE
Extending support of the Oneview_volume_attachment resource type to A…

### DIFF
--- a/lib/puppet/provider/oneview_volume_attachment/c7000.rb
+++ b/lib/puppet/provider/oneview_volume_attachment/c7000.rb
@@ -25,8 +25,6 @@ Puppet::Type::Oneview_volume_attachment.provide :c7000, parent: Puppet::OneviewR
 
   def initialize(*args)
     super(*args)
-    # Initializes the data so it is parsed only on exists and accessible throughout the methods
-    # This is not set here due to the 'resources' variable not being accessible in initialize
     @vas = []
   end
 

--- a/lib/puppet/provider/oneview_volume_attachment/c7000.rb
+++ b/lib/puppet/provider/oneview_volume_attachment/c7000.rb
@@ -17,7 +17,7 @@
 require_relative '../oneview_resource'
 
 Puppet::Type::Oneview_volume_attachment.provide :c7000, parent: Puppet::OneviewResource do
-  desc 'Provider for OneView Volume Attachment using the C7000 variant of the OneView API'
+  desc 'Provider for OneView Volume Attachments using the C7000 variant of the OneView API'
 
   confine true: login[:hardware_variant] == 'C7000'
 
@@ -27,7 +27,6 @@ Puppet::Type::Oneview_volume_attachment.provide :c7000, parent: Puppet::OneviewR
     super(*args)
     # Initializes the data so it is parsed only on exists and accessible throughout the methods
     # This is not set here due to the 'resources' variable not being accessible in initialize
-    @data = {}
     @vas = []
   end
 

--- a/lib/puppet/provider/oneview_volume_attachment/c7000.rb
+++ b/lib/puppet/provider/oneview_volume_attachment/c7000.rb
@@ -14,33 +14,21 @@
 # limitations under the License.
 ################################################################################
 
-require_relative '../login'
-require_relative '../common'
-require 'oneview-sdk'
+require_relative '../oneview_resource'
 
-Puppet::Type.type(:oneview_volume_attachment).provide(:oneview_volume_attachment) do
+Puppet::Type::Oneview_volume_attachment.provide :c7000, parent: Puppet::OneviewResource do
+  desc 'Provider for OneView Volume Attachment using the C7000 variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'C7000'
+
   mk_resource_methods
 
   def initialize(*args)
     super(*args)
-    @client = OneviewSDK::Client.new(login)
-    @resourcetype = OneviewSDK::VolumeAttachment
     # Initializes the data so it is parsed only on exists and accessible throughout the methods
     # This is not set here due to the 'resources' variable not being accessible in initialize
     @data = {}
     @vas = []
-  end
-
-  def self.instances
-    @client = OneviewSDK::Client.new(login)
-    matches = OneviewSDK::VolumeAttachment.find_by(@client, {})
-    matches.collect do |line|
-      name = line['name']
-      data = line.inspect
-      new(name: name,
-          ensure: :present,
-          data: data)
-    end
   end
 
   # Provider methods
@@ -122,7 +110,7 @@ Puppet::Type.type(:oneview_volume_attachment).provide(:oneview_volume_attachment
 
   def find_for_server_profile
     unless @data['name']
-      raise "A 'name' tag must be specified within data, containing the server profile name and/or server profile name/volume name"\
+      raise "A 'name' tag must be specified within data, containing the server profile name and/or server profile name/volume name "\
         'to find a specific storage volume attachment'
     end
     vas, volume = helper_retrieve_vas

--- a/lib/puppet/provider/oneview_volume_attachment/synergy.rb
+++ b/lib/puppet/provider/oneview_volume_attachment/synergy.rb
@@ -1,0 +1,21 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+Puppet::Type.type(:oneview_volume_attachment).provide :synergy, parent: :c7000 do
+  desc 'Provider for OneView Volume Attachment using the Synergy variant of the OneView API'
+
+  confine true: login[:hardware_variant] == 'Synergy'
+end

--- a/lib/puppet/provider/oneview_volume_attachment/synergy.rb
+++ b/lib/puppet/provider/oneview_volume_attachment/synergy.rb
@@ -15,7 +15,7 @@
 ################################################################################
 
 Puppet::Type.type(:oneview_volume_attachment).provide :synergy, parent: :c7000 do
-  desc 'Provider for OneView Volume Attachment using the Synergy variant of the OneView API'
+  desc 'Provider for OneView Volume Attachments using the Synergy variant of the OneView API'
 
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/spec/integration/provider/oneview_volume_attachment_c7000_spec.rb
+++ b/spec/integration/provider/oneview_volume_attachment_c7000_spec.rb
@@ -18,7 +18,7 @@
 # have unmanaged volumes in it.
 
 require 'spec_helper'
-require File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/puppet/provider/', 'login'))
+require_relative '../../../lib/puppet/provider/login'
 
 provider_class = Puppet::Type.type(:oneview_volume_attachment).provider(:c7000)
 storage_volume_template = login[:storage_volume_template] || 'Test'

--- a/spec/integration/provider/oneview_volume_attachment_c7000_spec.rb
+++ b/spec/integration/provider/oneview_volume_attachment_c7000_spec.rb
@@ -20,7 +20,7 @@
 require 'spec_helper'
 require File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/puppet/provider/', 'login'))
 
-provider_class = Puppet::Type.type(:oneview_volume_attachment).provider(:oneview_volume_attachment)
+provider_class = Puppet::Type.type(:oneview_volume_attachment).provider(:c7000)
 storage_volume_template = login[:storage_volume_template] || 'Test'
 server_profile_name = login[:server_profile_name] || 'OneViewSDK Test ServerProfile'
 volume_name = login[:volume_name] || 'Volume Test'
@@ -33,7 +33,8 @@ describe provider_class do
       data:
           {
             'name' => "#{storage_volume_template}, #{volume_name}"
-          }
+          },
+      provider: 'c7000'
     )
   end
 
@@ -47,7 +48,7 @@ describe provider_class do
 
   context 'given the minimum parameters' do
     it 'should be an instance of the provider oneview_volume_attachment' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_volume_attachment).provider(:oneview_volume_attachment)
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_volume_attachment).provider(:c7000)
     end
 
     it 'should be able to run through self.instances' do

--- a/spec/integration/provider/oneview_volume_attachment_synergy_spec.rb
+++ b/spec/integration/provider/oneview_volume_attachment_synergy_spec.rb
@@ -18,7 +18,7 @@
 # have unmanaged volumes in it.
 
 require 'spec_helper'
-require File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/puppet/provider/', 'login'))
+require_relative '../../../lib/puppet/provider/login'
 
 provider_class = Puppet::Type.type(:oneview_volume_attachment).provider(:synergy)
 storage_volume_template = login[:storage_volume_template] || 'Test'

--- a/spec/integration/provider/oneview_volume_attachment_synergy_spec.rb
+++ b/spec/integration/provider/oneview_volume_attachment_synergy_spec.rb
@@ -1,0 +1,83 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# NOTE: For all tests in this spec to pass, the volume attachment specified must
+# have unmanaged volumes in it.
+
+require 'spec_helper'
+require File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/puppet/provider/', 'login'))
+
+provider_class = Puppet::Type.type(:oneview_volume_attachment).provider(:synergy)
+storage_volume_template = login[:storage_volume_template] || 'Test'
+server_profile_name = login[:server_profile_name] || 'OneViewSDK Test ServerProfile'
+volume_name = login[:volume_name] || 'Volume Test'
+
+describe provider_class do
+  let(:resource) do
+    Puppet::Type.type(:oneview_volume_attachment).new(
+      name: 'Volume Attachment',
+      ensure: 'present',
+      data:
+          {
+            'name' => "#{storage_volume_template}, #{volume_name}"
+          },
+      provider: 'synergy'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  before(:each) do
+    provider.exists?
+  end
+
+  context 'given the minimum parameters' do
+    it 'should be an instance of the provider oneview_volume_attachment' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_volume_attachment).provider(:synergy)
+    end
+
+    it 'should be able to run through self.instances' do
+      expect(instance).to be
+    end
+
+    it 'should raise an error when the "present" ensurable is specified' do
+      expect { provider.create }.to raise_error(/Ensure state 'present' is unavailable for this resource/)
+    end
+    # This requires the VA to be created beforehand
+    # it 'should return that the volume attachment was found' do
+    #   expect(provider.found).to be
+    # end
+
+    it 'should return the list of extra unmanaged volumes' do
+      expect(provider.get_extra_unmanaged_volumes).to be
+    end
+
+    it 'should be able to remove extra unmanaged volumes' do
+      resource['data']['name'] = server_profile_name
+      expect(provider.remove_extra_unmanaged_volume).to be
+    end
+
+    it 'should return the list of paths from the VA' do
+      expect(provider.get_paths).to be
+    end
+
+    it 'should raise an error when the "present" ensurable is specified' do
+      expect { provider.destroy }.to raise_error(/Ensure state 'absent' is unavailable for this resource/)
+    end
+  end
+end

--- a/spec/unit/provider/oneview_volume_attachment_c7000_spec.rb
+++ b/spec/unit/provider/oneview_volume_attachment_c7000_spec.rb
@@ -1,0 +1,145 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+provider_class = Puppet::Type.type(:oneview_volume_attachment).provider(:c7000)
+api_version = login[:api_version] || 200
+resourcetype ||= if api_version == 200
+                   OneviewSDK::API200::VolumeAttachment
+                 else
+                   Object.const_get("OneviewSDK::API#{api_version}::C7000::VolumeAttachment")
+                 end
+
+describe provider_class, unit: true do
+  include_context 'shared context'
+
+  let(:resource) do
+    Puppet::Type.type(:oneview_volume_attachment).new(
+      name: 'VA',
+      ensure: 'present',
+      data:
+          {
+            'name' => 'Server Profile Attachment Demo, volume-attachment-demo'
+          }
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  let(:instance) { provider.class.instances.first }
+
+  context 'given the minimum parameters' do
+    before(:each) do
+      test = resourcetype.new(@client, resource['data'])
+      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      provider.exists?
+    end
+
+    it 'should able to find the specific VA' do
+      resource['data']['sanStorage'] = { 'volumeAttachments' => [{ 'volumeUri' => 'fake uri' }] }
+      resource['data']['uri'] = 'fake uri'
+      test = resourcetype.new(@client, resource['data'])
+      resource['data'].delete('sanStorage')
+      resource['data'].delete('uri')
+      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(OneviewSDK::ServerProfile).to receive(:find_by).with(anything, name: 'Server Profile Attachment Demo').and_return([test])
+      allow(OneviewSDK::Volume).to receive(:find_by).with(anything, name: 'volume-attachment-demo').and_return([test])
+      expect(provider.found).to be
+    end
+
+    it 'should raise an error if the ensurable present is used' do
+      resource['ensure'] = 'present'
+      expect { provider.create }.to raise_error(/Ensure state 'present' is unavailable for this resource/)
+    end
+
+    it 'should raise an error if the ensurable absent is used' do
+      resource['ensure'] = 'absent'
+      expect { provider.destroy }.to raise_error(/Ensure state 'absent' is unavailable for this resource/)
+    end
+
+    it 'should raise an error if there is no name for server profile' do
+      resource['data'].delete('name')
+      error_raised = "A 'name' tag must be specified within data, containing the server profile name and/or server profile "\
+                     'name/volume name to find a specific storage volume attachment'
+      expect { provider.find_for_server_profile }.to raise_error(error_raised)
+    end
+
+    it 'should be able to get a list of extra unmanaged volumes' do
+      resource['ensure'] = 'get_extra_unmanaged_volumes'
+      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new('members' => %w(first second)))
+      expect(provider.get_extra_unmanaged_volumes).to be
+    end
+
+    it 'should be able to remove the extra unmanaged volumes' do
+      resource['ensure'] = 'remove_extra_unmanaged_volume'
+      test = resourcetype.new(@client, resource['data'])
+      body = { type: 'ExtraUnmanagedStorageVolumes', resourceUri: resource['data']['uri'] }
+      allow(OneviewSDK::ServerProfile).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
+      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_post)
+        .with('/rest/storage-volume-attachments/repair', 'body' => body)
+        .and_return(FakeResponse.new('uri' => '/rest/fake'))
+      # expect_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new({'members' => ['first','second']}))
+      expect(provider.remove_extra_unmanaged_volume).to be
+    end
+  end
+
+  context 'given no data' do
+    let(:resource) do
+      Puppet::Type.type(:oneview_volume_attachment).new(
+        name: 'VA',
+        ensure: 'found'
+      )
+    end
+    it 'should able to find all VAs' do
+      test = resourcetype.new(@client, {})
+      allow(resourcetype).to receive(:find_by).with(anything, {}).and_return([test])
+      expect(provider.found).to be
+    end
+  end
+
+  context 'given the get paths attributes' do
+    let(:resource) do
+      Puppet::Type.type(:oneview_volume_attachment).new(
+        name: 'VA',
+        ensure: 'get_paths',
+        data:
+            {
+              'name' => 'ONEVIEW_PUPPET_TEST VA1',
+              'id'   => 'fake'
+            }
+      )
+    end
+
+    it 'should be able to get all paths if no id is provided' do
+      resource['data'] = { 'name' => 'ONEVIEW_PUPPET_TEST VA1' }
+      resource['data']['uri'] = '/rest/fake'
+      test = resourcetype.new(@client, resource['data'])
+      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new(%w(fake_path_1 fake_path_2)))
+      provider.exists?
+      expect(provider.get_paths).to be
+    end
+
+    it 'should be able to get a path by id if id is provided' do
+      test = resourcetype.new(@client, resource['data'])
+      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new(['fake_path_found']))
+      provider.exists?
+      expect(provider.get_paths).to be
+    end
+  end
+end

--- a/spec/unit/provider/oneview_volume_attachment_synergy_spec.rb
+++ b/spec/unit/provider/oneview_volume_attachment_synergy_spec.rb
@@ -20,7 +20,7 @@ api_version = login[:api_version] || 200
 resource_name = 'VolumeAttachment'
 resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
 
-describe provider_class, unit: true do
+describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
 
   let(:resource) do


### PR DESCRIPTION
Extending support of the Oneview_volume_attachment resource type to API300 on C7000 and Synergy

### Description
Adds support to the Oneview_volume_attachment resource


### Issues Resolved
Fixes #34

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
