### PR TITLE
Fix metadata for Puppet Forge requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
   "requirements": [
     {"name":"puppet","version_requirement":">= 4.1.0"},
     {"name": "ruby","version_requirement": ">=2.2.3"},
-    {"name": "oneview-sdk-ruby","version_requirement": "~>3.1"}
+    {"name": "oneview-sdk-ruby","version_requirement": ">=3.1.0"}
   ],
   "tags": [ "oneview", "hpe", "hewlett packard enterprise", "i3s", "image streamer", "bare-metal provisioning" ],
   "data_provider": null


### PR DESCRIPTION
### Description
Fixing metadata since puppet forge was not accepting it as either ~> and =

### Issues Resolved


### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
