### PR TITLE
Temporary fix - Use gem directly built from ruby-sdk repository instead of rubygems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,15 @@ rvm:
   - 2.2.5
   - 2.3.1
 
-before_install: gem update bundler
+before_install:
+  - gem update bundler
+  # This is for purposes of following the latest available resources on GitHub for oneview-sdk-ruby
+  - git clone https://github.com/HewlettPackard/oneview-sdk-ruby
+  - cd oneview-sdk-ruby
+  - gem build oneview-sdk.gemspec
+  - gem install ./oneview-sdk-3.1.0.gem
+  - cd ..
+  - rm -rf oneview-sdk-ruby
 
 script:
-- rspec spec/unit/ --tag unit
+  - rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ rvm:
 
 before_install:
   - gem update bundler
-  # This is for purposes of following the latest available resources on GitHub for oneview-sdk-ruby
+  # TODO: This MUST be removed before release. Remove from here.
+  # This is for purposes of following the latest available resources on GitHub for oneview-sdk-ruby, while development is ongoing there.
   - git clone https://github.com/HewlettPackard/oneview-sdk-ruby
   - cd oneview-sdk-ruby
   - gem build oneview-sdk.gemspec
   - gem install ./oneview-sdk-3.1.0.gem
   - cd ..
   - rm -rf oneview-sdk-ruby
+  # TODO: Remove up to here.
 
 script:
   - rake test


### PR DESCRIPTION
### Description
Making it so that Travis clones and builds the gem directly from ruby-sdk-repo instead of installing from rubygems

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
