### PR TITLE
Travis - Track the ruby-sdk during development instead of released gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,6 @@ rvm:
 
 before_install:
   - gem update bundler
-  # TODO: This MUST be removed before release. Remove from here.
-  # This is for purposes of following the latest available resources on GitHub for oneview-sdk-ruby, while development is ongoing there.
-  - git clone https://github.com/HewlettPackard/oneview-sdk-ruby
-  - cd oneview-sdk-ruby
-  - gem build oneview-sdk.gemspec
-  - gem install ./oneview-sdk-3.1.0.gem
-  - cd ..
-  - rm -rf oneview-sdk-ruby
-  # TODO: Remove up to here.
 
 script:
   - rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_install:
   - gem update bundler
 
 script:
-  - rake test
+  - bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source 'http://rubygems.org'
 gem 'coveralls', require: false
 gem 'facter', '>= 1.7.0'
 gem 'metadata-json-lint'
-gem 'oneview-sdk', '~> 3.1'
+# TODO: Remove the oneview-sdk line using github and reenable the one using oneview-sdk (with corrected version) BEFORE the release
+# gem 'oneview-sdk', '~> 3.1'
+gem 'oneview-sdk', git: 'https://github.com/HewlettPackard/oneview-sdk-ruby.git', branch: 'master'
 gem 'pry'
 gem 'puppet', '>= 4.1'
 gem 'puppet-lint', '>= 0.3.2'


### PR DESCRIPTION
### Description
Taking a more elegant/simple temporary approach for following the ruby-sdk during development. Less lines and mess.
This improves the fix from #90 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
