### PR TITLE
ADD tests for idempotency in Server Profile Template

### DIFF
--- a/spec/unit/provider/oneview_server_profile_template_c7000_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_template_c7000_spec.rb
@@ -39,7 +39,8 @@ describe provider_class, unit: true do
             {
               'name'                  => 'SPT',
               'enclosureGroupUri'     => '/rest/',
-              'serverHardwareTypeUri' => '/rest/'
+              'serverHardwareTypeUri' => '/rest/',
+              'description'           => 'description'
             },
         provider: 'c7000'
       )
@@ -77,6 +78,26 @@ describe provider_class, unit: true do
       allow(resourcetype).to receive(:find_by).and_return([])
       allow_any_instance_of(resourcetype).to receive(:create).and_return(resourcetype.new(@client, resource['data']))
       expect(provider.exists?).to eq(false)
+      expect(provider.create).to be
+    end
+
+    it 'should create when resource does not exist' do
+      allow(resourcetype).to receive(:find_by).and_return([])
+      expect(provider.exists?).to eq(false)
+      expect_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      expect(provider.create).to be
+    end
+
+    it 'should not create when resource is compliant' do
+      expect(provider.exists?).to eq(true)
+      expect(resourcetype).not_to receive(:create)
+      expect(provider.create).to be
+    end
+
+    it 'should update when resource is not compliant' do
+      test['description'] = 'new description'
+      expect_any_instance_of(resourcetype).to receive(:update)
+      expect_any_instance_of(resourcetype).not_to receive(:create)
       expect(provider.create).to be
     end
 

--- a/spec/unit/provider/oneview_server_profile_template_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_template_synergy_spec.rb
@@ -38,7 +38,8 @@ describe provider_class, unit: true, if: api_version >= 300 do
             {
               'name'                  => 'SPT',
               'enclosureGroupUri'     => '/rest/',
-              'serverHardwareTypeUri' => '/rest/'
+              'serverHardwareTypeUri' => '/rest/',
+              'description'           => 'description'
             },
         provider: 'synergy'
       )
@@ -76,6 +77,26 @@ describe provider_class, unit: true, if: api_version >= 300 do
       allow(resourcetype).to receive(:find_by).and_return([])
       allow_any_instance_of(resourcetype).to receive(:create).and_return(resourcetype.new(@client, resource['data']))
       expect(provider.exists?).to eq(false)
+      expect(provider.create).to be
+    end
+
+    it 'should create when resource does not exist' do
+      allow(resourcetype).to receive(:find_by).and_return([])
+      expect(provider.exists?).to eq(false)
+      expect_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      expect(provider.create).to be
+    end
+
+    it 'should not create when resource is compliant' do
+      expect(provider.exists?).to eq(true)
+      expect(resourcetype).not_to receive(:create)
+      expect(provider.create).to be
+    end
+
+    it 'should update when resource is not compliant' do
+      test['description'] = 'new description'
+      expect_any_instance_of(resourcetype).to receive(:update)
+      expect_any_instance_of(resourcetype).not_to receive(:create)
       expect(provider.create).to be
     end
 


### PR DESCRIPTION
### Description
ADD tests for idempotency in Server Profile Template

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
