### PR TITLE
Add compact declaration to Logical interconnect group and fix unexpected behavior on the resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Image_streamer_os_volume
 - Image_streamer_plan_script
 
+#### Bug fixes & Enhancements:
+- [#105](https://github.com/HewlettPackard/oneview-puppet/issues/105) Create or update uplink sets through logical interconnect groups
+
 # 2.1.0 (2017-02-03)
 ### Version highlights:
 1. Added full support to OneView Rest API version 300 for the hardware variants C7000 and Synergy to the already existing features.

--- a/examples/logical_interconnect_group.pp
+++ b/examples/logical_interconnect_group.pp
@@ -1,62 +1,288 @@
 ################################################################################
 # (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
 
-# The Interconnects and Uplink Sets can also be declared as follows:
-oneview_logical_interconnect_group{'Puppet LIG C7000':
+# This example uses the compact syntax (not api standard) to create a Logical interconnect group with its uplink sets, networkuris and
+  # internalNetworkUris. It should be simpler than passing all the information required to do so usually.
+oneview_logical_interconnect_group{'Puppet LIG C7000 Simplified':
   ensure => 'present',
   data   => {
-    name          => 'Puppet LIG C7000',
-    enclosureType => 'C7000',
-    # uplinkSets => ['Puppet Uplink Set'],
-    interconnects =>
-    [
+    'name'                => 'PUPPET_TEST_LIG',
+    'type'                => 'logical-interconnect-groupV300',
+    'enclosureType'       => 'C7000',
+    'state'               => 'Active',
+    'uplinkSets'          => [
       {
-        bay  => 1,
-        type => 'HP VC FlexFabric 10Gb/24-Port Module'
-      },
-      # {
-      #   bay  => 2,
-      #   type => 'HP VC FlexFabric 10Gb/24-Port Module'
-      # },
-    ]
+        'name'                => 'TUNNEL_ETH_UP_01',
+        'ethernetNetworkType' => 'Tunnel',
+        'networkType'         => 'Ethernet',
+        'lacpTimer'           => 'Short',
+        'mode'                => 'Auto',
+        'uplink_ports'        => [{ bay  => 1,
+                                    port => 'X5' },
+                                  { bay  => 1,
+                                    port => 'X6' },
+                                  { bay  => 2,
+                                    port => 'X7' },
+                                  { bay  => 2,
+                                    port => 'X8' }
+                                    ],
+        'networkUris'         => [
+          'tunnelnet1'
+        ]
+      }
+    ],
+    'interconnects'       => [
+      { bay  => 1,
+        type => 'HP VC FlexFabric 10Gb/24-Port Module' },
+      { bay  => 2,
+        type => 'HP VC FlexFabric 10Gb/24-Port Module' }
+        ],
+    'internalNetworkUris' => ['test']
+  },
+}
+
+# This example creates a Logical Interconnect Group, with a similar structure to the one listed above, but using a more typical API payload.
+oneview_logical_interconnect_group{'Puppet LIG C7000 Full':
+  ensure => 'present',
+  data   => {
+    'type'                    => 'logical-interconnect-groupV300',
+    'name'                    => 'ONEVIEW_SDK_TEST_LIG',
+    'enclosureType'           => 'C7000',
+    'state'                   => 'Active',
+    'uplinkSets'              => [
+      {
+        'name'                   => 'TUNNEL_ETH_UP_01',
+        'ethernetNetworkType'    => 'Tunnel',
+        'networkType'            => 'Ethernet',
+        'logicalPortConfigInfos' => [
+          {
+            'desiredSpeed'    => 'Auto',
+            'logicalLocation' => {
+              'locationEntries' => [
+                {
+                  'relativeValue' => 1,
+                  'type'          => 'Bay'
+                },
+                {
+                  'relativeValue' => 1,
+                  'type'          => 'Enclosure'
+                },
+                {
+                  'relativeValue' => 21,
+                  'type'          => 'Port'
+                }
+              ]
+            }
+          },
+          {
+            'desiredSpeed'    => 'Auto',
+            'logicalLocation' => {
+              'locationEntries' => [
+                {
+                  'relativeValue' => 1,
+                  'type'          => 'Bay'
+                },
+                {
+                  'relativeValue' => 1,
+                  'type'          => 'Enclosure'
+                },
+                {
+                  'relativeValue' => 22,
+                  'type'          => 'Port'
+                }
+              ]
+            }
+          },
+          {
+            'desiredSpeed'    => 'Auto',
+            'logicalLocation' => {
+              'locationEntries' => [
+                {
+                  'relativeValue' => 2,
+                  'type'          => 'Bay'
+                },
+                {
+                  'relativeValue' => 1,
+                  'type'          => 'Enclosure'
+                },
+                {
+                  'relativeValue' => 23,
+                  'type'          => 'Port'
+                }
+              ]
+            }
+          },
+          {
+            'desiredSpeed'    => 'Auto',
+            'logicalLocation' => {
+              'locationEntries' => [
+                {
+                  'relativeValue' => 2,
+                  'type'          => 'Bay'
+                },
+                {
+                  'relativeValue' => 1,
+                  'type'          => 'Enclosure'
+                },
+                {
+                  'relativeValue' => 24,
+                  'type'          => 'Port'
+                }
+              ]
+            }
+          }
+        ],
+        'lacpTimer'              => 'Short',
+        'mode'                   => 'Auto',
+        'networkUris'            => [
+          '/rest/ethernet-networks/eca5f86a-2936-44c7-b3e1-8b1e01c89426'
+        ]
+      }
+    ],
+    'interconnectMapTemplate' => {
+      'interconnectMapEntryTemplates' => [
+        {
+          'logicalLocation'                => {
+            'locationEntries' => [
+              {
+                'relativeValue'   => 1,
+                'type'            => 'Bay'
+              },
+              {
+                'relativeValue'   => 1,
+                'type'            => 'Enclosure'
+              }
+            ]
+          },
+          'permittedInterconnectTypeUri'   => '/rest/interconnect-types/005ef42f-eb2e-44ff-bc6d-d736d1705f72'
+        },
+        {
+          'logicalLocation'                => {
+            'locationEntries' => [
+              {
+                'relativeValue'   => 2,
+                'type'            => 'Bay'
+              },
+              {
+                'relativeValue'   => 1,
+                'type'            => 'Enclosure'
+              }
+            ]
+          },
+          'permittedInterconnectTypeUri'   => '/rest/interconnect-types/005ef42f-eb2e-44ff-bc6d-d736d1705f72'
+        },
+        {
+          'logicalLocation' => {
+            'locationEntries' => [
+              {
+                'relativeValue'   => 3,
+                'type'            => 'Bay'
+              },
+              {
+                'relativeValue'   => 1,
+                'type'            => 'Enclosure'
+              }
+            ]
+          },
+        },
+        {
+          'logicalLocation' => {
+            'locationEntries' => [
+              {
+                'relativeValue'   => 4,
+                'type'            => 'Bay'
+              },
+              {
+                'relativeValue'   => 1,
+                'type'            => 'Enclosure'
+              }
+            ]
+          },
+        },
+        {
+          'logicalLocation' => {
+            'locationEntries' => [
+              {
+                'relativeValue'   => 5,
+                'type'            => 'Bay'
+              },
+              {
+                'relativeValue'   => 1,
+                'type'            => 'Enclosure'
+              }
+            ]
+          },
+        },
+        {
+          'logicalLocation' => {
+            'locationEntries' => [
+              {
+                'relativeValue'   => 6,
+                'type'            => 'Bay'
+              },
+              {
+                'relativeValue'   => 1,
+                'type'            => 'Enclosure'
+              }
+            ]
+          },
+        },
+        {
+          'logicalLocation' => {
+            'locationEntries' => [
+              {
+                'relativeValue'   => 7,
+                'type'            => 'Bay'
+              },
+              {
+                'relativeValue'   => 1,
+                'type'            => 'Enclosure'
+              }
+            ]
+          },
+        },
+        {
+          'logicalLocation' => {
+            'locationEntries' => [
+              {
+                'relativeValue'   => 8,
+                'type'            => 'Bay'
+              },
+              {
+                'relativeValue'   => 1,
+                'type'            => 'Enclosure'
+              }
+            ]
+          },
+        }
+      ]
+    }
   }
 }
 
-oneview_logical_interconnect_group{'Logical Interconnect Group Edit':
-  ensure  => 'present',
-  require => Oneview_logical_interconnect_group['Puppet LIG C7000'],
-  data    => {
-    name     => 'Puppet LIG C7000',
-    new_name => 'Edited LIG'
-  }
-}
 
 oneview_logical_interconnect_group{'Logical Interconnect Group Found':
   ensure  => 'found',
-  require => Oneview_logical_interconnect_group['Logical Interconnect Group Edit'],
-  # data   => {
-  #   name => 'Edited LIG'
-  # }
 }
 
 oneview_logical_interconnect_group{'Logical Interconnect Group Get Default Settings':
   ensure  => 'get_default_settings',
   require => Oneview_logical_interconnect_group['Logical Interconnect Group Found'],
   data    => {
-    name => 'Edited LIG'
+    name => 'PUPPET_TEST_LIG'
   }
 }
 
@@ -64,14 +290,20 @@ oneview_logical_interconnect_group{'Logical Interconnect Group Get Settings':
   ensure  => 'get_settings',
   require => Oneview_logical_interconnect_group['Logical Interconnect Group Get Default Settings'],
   data    => {
-    name => 'Edited LIG'
+    name => 'PUPPET_TEST_LIG'
   }
 }
 
-oneview_logical_interconnect_group{'Logical Interconnect Group Destroy':
-  ensure  => 'absent',
-  require => Oneview_logical_interconnect_group['Logical Interconnect Group Get Settings'],
-  data    => {
-    name => 'Edited LIG'
+oneview_logical_interconnect_group{'Logical Interconnect Group Destroy Oneview SDK':
+  ensure => 'absent',
+  data   => {
+    name => 'ONEVIEW_SDK_TEST_LIG'
+  }
+}
+
+oneview_logical_interconnect_group{'Logical Interconnect Group Destroy Puppet Test':
+  ensure => 'absent',
+  data   => {
+    name => 'PUPPET_TEST_LIG'
   }
 }

--- a/examples/logical_interconnect_group.pp
+++ b/examples/logical_interconnect_group.pp
@@ -1,14 +1,14 @@
 ################################################################################
 # (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
 #
-# Licensed under the Apache License, Version 2.0 (the 'License');
+# Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an 'AS IS' BASIS,
+# distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.

--- a/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
@@ -23,19 +23,28 @@ Puppet::Type::Oneview_logical_interconnect_group.provide :c7000, parent: Puppet:
 
   mk_resource_methods
 
+  def initialize(*args)
+    super(*args)
+    @uplink_sets = {}
+    @interconnects = {}
+    @internal_network_uris = {}
+  end
+
   def exists?
     super
     # Assignments and helpers
     @interconnects = @data.delete('interconnects')
-    uri_getters('internalNetworkUris')
-    uri_getters('uplinkSets')
-    !@resourcetype.find_by(@client, @data).empty?
+    @uplink_sets = @data.delete('uplinkSets')
+    @internal_network_uris = @data.delete('internalNetworkUris')
+    @data['uplinkSets'] = parse_uplink_sets if @uplink_sets
+    @data['interconnectMapTemplate'] = parse_interconnects if @interconnects
+    @data['internalNetworkUris'] = parse_internal_networks if @internal_network_uris
+    @resourcetype.find_by(@client, @data).any?
   end
 
   def create
     new_name = @data.delete('new_name')
     lig = @resourcetype.new(@client, @data)
-    add_interconnects(lig) if @interconnects
     @data['new_name'] = new_name if new_name
     return true if resource_update(@data, @resourcetype)
     lig.create
@@ -51,30 +60,69 @@ Puppet::Type::Oneview_logical_interconnect_group.provide :c7000, parent: Puppet:
 
   def get_default_settings
     Puppet.notice("\n\nLogical Interconnect Group Default Settings\n")
-    pretty get_single_resource_instance.get_default_settings
+    pretty @resourcetype.get_default_settings(@client)
     true
   end
 
-  def add_interconnects(lig)
-    @interconnects.each do |item|
-      lig.add_interconnect(item['bay'].to_i, item['type'])
+  # Helpers
+
+  # Method to allow for names to be used instead of uris for the field internalNetworkUris
+  def parse_internal_networks
+    list = []
+    @internal_network_uris.each do |item|
+      next if item.to_s[0..6].include?('/rest/')
+      net = OneviewSDK.resource_named(:EthernetNetwork, login[:api_version], login[:hardware_variant]).find_by(@client, name: item)
+      raise("The resource #{item} does not exist.") unless net.first
+      list.push(net.first['uri'])
     end
+    list
   end
 
-  # Grabs the uplink sets uris
-  def uri_getters(field)
-    return unless @data[field]
-    list = []
-    @data[field].each do |item|
-      next if item.to_s[0..6].include?('/rest/')
-      set = if field.eql?('uplinkSets')
-              OneviewSDK::UplinkSet.find_by(@client, name: item)
-            else
-              OneviewSDK::EthernetNetwork.find_by(@client, name: item)
-            end
-      raise("The resource #{item} does not exist.") unless set.first
-      list.push(set.first['uri'])
+  # Method to allow for a compact syntax to be used for declaring interconnects inside the LIG
+  def parse_interconnects
+    puts 'INSIDE INTERCONNECT'
+    lig = OneviewSDK.resource_named(:LogicalInterconnectGroup, login[:api_version], login[:hardware_variant]).new(@client, {})
+    @interconnects.each do |item|
+      puts "item bay and type: #{item['bay']} #{item['type']}"
+      lig.add_interconnect(item['bay'].to_i, item['type'])
     end
-    @data[field] = list
+    lig['interconnectMapTemplate']
+  end
+
+  # Method to allow for a compact syntax to be used for creating LIG uplink sets
+  def parse_uplink_sets
+    api_version = login[:api_version]
+    hardware_variant = login[:hardware_variant]
+    lig = OneviewSDK.resource_named(:LogicalInterconnectGroup, api_version, hardware_variant).new(@client, {})
+    @uplink_sets.each do |uplink_set_params|
+      network_uris = uplink_set_params.delete('networkUris')
+      uplink_ports = uplink_set_params.delete('uplink_ports')
+      uplink_set = OneviewSDK.resource_named(:LIGUplinkSet, api_version, hardware_variant).new(@client, uplink_set_params)
+      set_network(uplink_set, uplink_set_params['networkType'], network_uris) if network_uris
+      set_uplink_ports(uplink_set, uplink_ports) if uplink_ports
+      lig.add_uplink_set(uplink_set)
+    end
+    lig.data['uplinkSets']
+  end
+
+  # Method to allow using a name instead of uri for networks inside the UplinkSet
+  def set_network(uplink_set, network_type, network_uris)
+    net_type = network_type == 'Ethernet' ? :EthernetNetwork : FCNetwork
+    net_class = OneviewSDK.resource_named(net_type, login[:api_version], login[:hardware_variant])
+    network_uris.each do |network_uri|
+      next if network_uri.to_s[0..6].include?('/rest/')
+      net = net_class.new(@client, name: network_uri)
+      raise "Network in networkUris not found. Name specified for the network: #{network_uri}" unless net.retrieve!
+      uplink_set.add_network(net)
+    end
+    uplink_set
+  end
+
+  # Method to add the uplink bay & port to the LIGuplinkSet using helpers
+  def set_uplink_ports(uplink_set, uplink_ports)
+    uplink_ports.each do |uplink_port|
+      uplink_set.add_uplink(uplink_port['bay'], uplink_port['port'])
+    end
+    uplink_set
   end
 end

--- a/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
@@ -80,10 +80,8 @@ Puppet::Type::Oneview_logical_interconnect_group.provide :c7000, parent: Puppet:
 
   # Method to allow for a compact syntax to be used for declaring interconnects inside the LIG
   def parse_interconnects
-    puts 'INSIDE INTERCONNECT'
     lig = OneviewSDK.resource_named(:LogicalInterconnectGroup, login[:api_version], login[:hardware_variant]).new(@client, {})
     @interconnects.each do |item|
-      puts "item bay and type: #{item['bay']} #{item['type']}"
       lig.add_interconnect(item['bay'].to_i, item['type'])
     end
     lig['interconnectMapTemplate']

--- a/lib/puppet/provider/oneview_logical_interconnect_group/synergy.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/synergy.rb
@@ -19,6 +19,14 @@ Puppet::Type.type(:oneview_logical_interconnect_group).provide :synergy, parent:
 
   confine true: login[:hardware_variant] == 'Synergy'
 
+  def parse_interconnects
+    lig = OneviewSDK.resource_named(:LogicalInterconnectGroup, login[:api_version], 'Synergy').new(@client, {})
+    @interconnects.each do |item|
+      lig.add_interconnect(item['bay'].to_i, item['type'], item['logical_downlink'], item['enclosure_index'])
+    end
+    lig['interconnectMapTemplate']
+  end
+
   def get_default_settings
     Puppet.notice("\n\nLogical Interconnect Group Default Settings\n")
     pretty @resourcetype.get_default_settings

--- a/spec/unit/provider/oneview_logical_interconnect_group_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_group_synergy_spec.rb
@@ -20,10 +20,11 @@ require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_logical_interconnect_group).provider(:synergy)
 api_version = login[:api_version] || 300
-resource_name = 'LogicalInterconnectGroup'
-resourcetype ||= Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless login[:api_version] == 200
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
+  resourcetype ||= OneviewSDK.resource_named(:LogicalInterconnectGroup, api_version, 'Synergy')
+  interconnect_type ||= OneviewSDK.resource_named(:Interconnect, api_version, 'Synergy')
+
   include_context 'shared context'
 
   let(:resource) do
@@ -60,6 +61,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
   context 'given the min parameters' do
     before(:each) do
       allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(interconnect_type).to receive(:get_type).and_return('uri' => '/fake/interconnect_type_uri')
       provider.exists?
     end
 
@@ -74,21 +76,17 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
     it 'runs through the create method' do
       allow(resourcetype).to receive(:find_by).and_return([])
-      allow(OneviewSDK::UplinkSet).to receive(:find_by)
-        .and_return([OneviewSDK::UplinkSet.new(@client, name: 'testup', uri: '/rest/fakeup')])
       allow(OneviewSDK::EthernetNetwork).to receive(:find_by)
         .and_return([OneviewSDK::EthernetNetwork.new(@client, name: 'testnet', uri: '/rest/fakenet')])
-      allow_any_instance_of(resourcetype).to receive(:add_interconnect).with(1, 'HP VC FlexFabric 10Gb/24-Port Module').and_return('')
+      allow_any_instance_of(resourcetype).to receive(:add_interconnect).and_return('')
       allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
       resource['data']['interconnects'] = [{ 'bay' => 1, 'type' => 'HP VC FlexFabric 10Gb/24-Port Module' }]
-      resource['data']['uplinkSets'] = ['test']
       resource['data']['internalNetworkUris'] = [%w(testnet1 testnet2)]
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to get the default settings' do
-      provider.exists?
       allow(resourcetype).to receive(:get_default_settings).and_return('Test')
       expect(provider.get_default_settings).to be
     end


### PR DESCRIPTION
### Description
Adds a compact version of uplink set creation and interconnect declaration to the LIG resource. Also fixes some unexpected behaviors like listing a full payload with uplinkset and interconnects resulting in failure.

### Issues Resolved
#105 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
