### PR TITLE
Changed get_class method to work for Image Streamer resources

### DIFF
--- a/lib/puppet/provider/uri_parsing.rb
+++ b/lib/puppet/provider/uri_parsing.rb
@@ -103,6 +103,7 @@ end
 
 def get_class(key)
   sub_module = OneviewSDK::ImageStreamer::Client == @client.class ? 'ImageStreamer::' : ''
+  variant = OneviewSDK::Client == @client.class && @client.api_version > 200 ? "#{resource_variant}::" : ''
   resource_name = "#{key.to_s[0].upcase}#{key[1..key.size - 4]}"
-  Object.const_get("OneviewSDK::#{sub_module}API#{@client.api_version}::#{resource_name}")
+  Object.const_get("OneviewSDK::#{sub_module}API#{@client.api_version}::#{variant}#{resource_name}")
 end

--- a/lib/puppet/provider/uri_parsing.rb
+++ b/lib/puppet/provider/uri_parsing.rb
@@ -102,6 +102,8 @@ def uri_recursive_array(data)
 end
 
 def get_class(key)
-  # this gets the SDK class based on key.to_s, removing 'Uri' and capitalizing the 1st letter
-  Object.const_get("OneviewSDK::#{key.to_s[0].upcase}#{key[1..key.size - 4]}")
+  is_image_streamer = OneviewSDK::ImageStreamer::Client == @client.class
+  resource_name = "#{key.to_s[0].upcase}#{key[1..key.size - 4]}"
+  return Object.const_get("OneviewSDK::API#{@client.api_version}::#{resource_name}") unless is_image_streamer
+  Object.const_get("OneviewSDK::ImageStreamer::API#{@client.api_version}::#{resource_name}")
 end

--- a/lib/puppet/provider/uri_parsing.rb
+++ b/lib/puppet/provider/uri_parsing.rb
@@ -102,8 +102,7 @@ def uri_recursive_array(data)
 end
 
 def get_class(key)
-  is_image_streamer = OneviewSDK::ImageStreamer::Client == @client.class
+  sub_module = OneviewSDK::ImageStreamer::Client == @client.class ? 'ImageStreamer::' : ''
   resource_name = "#{key.to_s[0].upcase}#{key[1..key.size - 4]}"
-  return Object.const_get("OneviewSDK::API#{@client.api_version}::#{resource_name}") unless is_image_streamer
-  Object.const_get("OneviewSDK::ImageStreamer::API#{@client.api_version}::#{resource_name}")
+  Object.const_get("OneviewSDK::#{sub_module}API#{@client.api_version}::#{resource_name}")
 end

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -23,6 +23,14 @@ RSpec.shared_context 'shared context', a: :b do
   end
 end
 
+RSpec.shared_context 'shared context OneView API 200', a: :b do
+  before :each do
+    api_version = 200
+    options = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123', api_version: api_version }
+    @client = OneviewSDK::Client.new(options)
+  end
+end
+
 RSpec.shared_context 'shared context Image Streamer', a: :b do
   before :each do
     api_version = 300

--- a/spec/unit/provider/uri_parsing_spec.rb
+++ b/spec/unit/provider/uri_parsing_spec.rb
@@ -34,7 +34,7 @@ describe 'uri_parsing', unit: true do
     include_context 'shared context'
 
     it 'should get the classname to find a resource' do
-      expect(get_class('enclosureUri')).to eq OneviewSDK::Enclosure
+      expect(get_class('enclosureUri')).to eq OneviewSDK::API300::Enclosure
     end
 
     it 'should raise error when class is not found' do

--- a/spec/unit/provider/uri_parsing_spec.rb
+++ b/spec/unit/provider/uri_parsing_spec.rb
@@ -21,6 +21,8 @@ describe 'uri_parsing', unit: true do
   describe 'given Image Streamer resources' do
     include_context 'shared context Image Streamer'
 
+    let(:resource_variant) { 'does not apply' }
+
     it 'should get the classname to find a resource' do
       expect(get_class('goldenImageUri')).to eq OneviewSDK::ImageStreamer::API300::GoldenImage
     end
@@ -30,11 +32,27 @@ describe 'uri_parsing', unit: true do
     end
   end
 
-  describe 'given OneView resources' do
+  describe 'given OneView resources and API Version 300' do
     include_context 'shared context'
 
+    let(:resource_variant) { 'C7000' }
+
     it 'should get the classname to find a resource' do
-      expect(get_class('enclosureUri')).to eq OneviewSDK::API300::Enclosure
+      expect(get_class('enclosureUri')).to eq OneviewSDK::API300::C7000::Enclosure
+    end
+
+    it 'should raise error when class is not found' do
+      expect { get_class('invalidUri') }.to raise_error(NameError)
+    end
+  end
+
+  describe 'given OneView resources and API Version 200' do
+    include_context 'shared context OneView API 200'
+
+    let(:resource_variant) { 'C7000' }
+
+    it 'should get the classname to find a resource' do
+      expect(get_class('enclosureUri')).to eq OneviewSDK::API200::Enclosure
     end
 
     it 'should raise error when class is not found' do

--- a/spec/unit/provider/uri_parsing_spec.rb
+++ b/spec/unit/provider/uri_parsing_spec.rb
@@ -1,0 +1,44 @@
+################################################################################
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+require_relative '../../../lib/puppet/provider/uri_parsing.rb'
+
+describe 'uri_parsing', unit: true do
+  describe 'given Image Streamer resources' do
+    include_context 'shared context Image Streamer'
+
+    it 'should get the classname to find a resource' do
+      expect(get_class('goldenImageUri')).to eq OneviewSDK::ImageStreamer::API300::GoldenImage
+    end
+
+    it 'should raise error when class is not found' do
+      expect { get_class('invalidUri') }.to raise_error(NameError)
+    end
+  end
+
+  describe 'given OneView resources' do
+    include_context 'shared context'
+
+    it 'should get the classname to find a resource' do
+      expect(get_class('enclosureUri')).to eq OneviewSDK::Enclosure
+    end
+
+    it 'should raise error when class is not found' do
+      expect { get_class('invalidUri') }.to raise_error(NameError)
+    end
+  end
+end


### PR DESCRIPTION
### Description
Changed get_class method from uri_parsing.rb to work for Image Streamer resources.

### Issues Resolved
This is required for Image Streamer resources which dependends on other resources.

For example Golden Image:
```puppet
data   => {
  buildPlanUri  => 'Name of the build plan'
}
```
After this change, an user will be able to provide a name instead of a URI for Image Streamer resources.

Required for #99 and some other Image Streamer resources to be implemented in future.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
