### PR TITLE
Changes to load Image Streamer auth settings from fixture

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,6 +84,10 @@ RSpec.configure do |config|
     end
   end
 
+  if config.filter_manager.inclusions.rules[:unit]
+    ENV['IMAGE_STREAMER_AUTH_FILE'] = 'spec/support/fixtures/unit/provider/login_image_streamer.json'
+  end
+
   config.before(:each) do
     # TODO: Puppet: Probably reverify this once we have have different test profiles
     if config.filter_manager.inclusions.rules[:unit]


### PR DESCRIPTION
### Description
Enable run Image Streamer unit tests with no auth files/environment variables set by the user.

### Issues Resolved
#103 (partial, fixes the issue running Image Streamer unit specs)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
