### PR TITLE
Simplify login into i3s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Bug fixes & Enhancements:
 - [#105](https://github.com/HewlettPackard/oneview-puppet/issues/105) Create or update uplink sets through logical interconnect groups
 - [#119](https://github.com/HewlettPackard/oneview-puppet/issues/119) Update unit tests to match updated remove_extra_unmanaged_volume from oneview-ruby-sdk
+- [#116](https://github.com/HewlettPackard/oneview-puppet/issues/116) Simplify login to i3s
 
 # 2.1.0 (2017-02-03)
 ### Version highlights:

--- a/README.md
+++ b/README.md
@@ -94,15 +94,22 @@ Once the authentication is prepared and the manifests containing the resources a
 The attributes required for authenticating with your HPE Synergy Image Streamer Appliance are:
 
 * `IMAGE_STREAMER_URL` - The web address for the HPE Image Streamer appliance. For example, https://imagestreamer.example.com
-* `IMAGE_STREAMER_TOKEN` - The authentication token for the HPE Image Streamer. This is the same token used to access the HPE OneView REST API.
 * `IMAGE_STREAMER_API_VERSION` - The API version for the HPE Image Streamer. This defaults to **300**
 * `IMAGE_STREAMER_LOG_LEVEL` - The log level of the HPE Image Streamer appliance. This defaults to **info**
 * `IMAGE_STREAMER_SSL_ENABLED` - HPE recommends setting this value to **true**
+
+The following attribute must be set only if you haven't configured the credentials to authenticate with your HPE OneView Appliance:
+
+* `IMAGE_STREAMER_TOKEN` - The authentication token for the HPE Image Streamer. This is the same token used to access the HPE OneView REST API.
+
+:exclamation: **NOTE:** All information stored on the login file or json files should be in clear text. To avoid security issues HPE recommends verifying the access permissions for those files.
 
 
 You can assign attributes for your appliances using three methods:
 
 1. Create a json file named `login_image_streamer.json` on your working directory, and enter the authentication information for your appliance. See [login_image_streamer.json](examples/login_image_streamer.json) for an example.
+
+You must provide a token only if you haven't configured the credentials to authenticate with your HPE OneView Appliance.
 
 2. If you do not want to use the login file on the working directory, any json file containing the authentication information for the appliance can be used by setting the following environment variable:
 

--- a/lib/puppet/provider/common.rb
+++ b/lib/puppet/provider/common.rb
@@ -121,3 +121,8 @@ def extract_resource_name(class_name)
   shift_prefix = Regexp.last_match.nil? ? 2 : 1
   class_name.split('::')[2].split('_').drop(shift_prefix).collect(&:capitalize).join
 end
+
+def create_image_streamer_client
+  return OneviewSDK::ImageStreamer::Client.new(login_image_streamer) unless oneview_credentials_set?
+  OneviewSDK::Client.new(login).new_i3s_client(login_image_streamer)
+end

--- a/lib/puppet/provider/common.rb
+++ b/lib/puppet/provider/common.rb
@@ -121,8 +121,3 @@ def extract_resource_name(class_name)
   shift_prefix = Regexp.last_match.nil? ? 2 : 1
   class_name.split('::')[2].split('_').drop(shift_prefix).collect(&:capitalize).join
 end
-
-def create_image_streamer_client
-  return OneviewSDK::ImageStreamer::Client.new(login_image_streamer) unless oneview_credentials_set?
-  OneviewSDK::Client.new(login).new_i3s_client(login_image_streamer)
-end

--- a/lib/puppet/provider/image_streamer_resource.rb
+++ b/lib/puppet/provider/image_streamer_resource.rb
@@ -38,10 +38,5 @@ module Puppet
       api_version = login_image_streamer[:api_version] || 300
       Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}")
     end
-
-    def create_image_streamer_client
-      return OneviewSDK::ImageStreamer::Client.new(login_image_streamer) unless oneview_credentials_set?
-      OneviewSDK::Client.new(login).new_i3s_client(login_image_streamer)
-    end
   end
 end

--- a/lib/puppet/provider/image_streamer_resource.rb
+++ b/lib/puppet/provider/image_streamer_resource.rb
@@ -22,11 +22,15 @@ module Puppet
     desc 'Base provider for Image Streamer resources'
 
     def client
-      create_image_streamer_client
+      self.class.client
     end
 
     def self.client
-      create_image_streamer_client
+      credentials_set = ENV['ONEVIEW_AUTH_FILE'] || ENV['ONEVIEW_URL'] ||
+                        File.exist?(File.expand_path(Dir.pwd + '/login.json', __FILE__))
+
+      return OneviewSDK::Client.new(login).new_i3s_client(login_image_streamer) if credentials_set
+      OneviewSDK::ImageStreamer::Client.new(login_image_streamer)
     end
 
     def ov_resource_type

--- a/lib/puppet/provider/image_streamer_resource.rb
+++ b/lib/puppet/provider/image_streamer_resource.rb
@@ -22,11 +22,11 @@ module Puppet
     desc 'Base provider for Image Streamer resources'
 
     def client
-      OneviewSDK::ImageStreamer::Client.new(login_image_streamer)
+      create_image_streamer_client
     end
 
     def self.client
-      OneviewSDK::ImageStreamer::Client.new(login_image_streamer)
+      create_image_streamer_client
     end
 
     def ov_resource_type
@@ -37,6 +37,11 @@ module Puppet
     def self.ov_resource_type
       api_version = login_image_streamer[:api_version] || 300
       Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}")
+    end
+
+    def create_image_streamer_client
+      return OneviewSDK::ImageStreamer::Client.new(login_image_streamer) unless oneview_credentials_set?
+      OneviewSDK::Client.new(login).new_i3s_client(login_image_streamer)
     end
   end
 end

--- a/lib/puppet/provider/login.rb
+++ b/lib/puppet/provider/login.rb
@@ -16,43 +16,28 @@
 
 require 'json'
 
-def oneview_options
-  {
+# This method returns the information necessary in order to log in to the Oneview Appliance
+def login
+  options = {
     type:         'OneView',
     file_env_var: 'ONEVIEW_AUTH_FILE',
     env_var_url:  'ONEVIEW_URL',
     filename:     '/login.json'
   }
-end
-
-def image_streamer_options
-  {
-    type:         'Image Streamer',
-    file_env_var: 'IMAGE_STREAMER_AUTH_FILE',
-    env_var_url:  'IMAGE_STREAMER_URL',
-    filename:     '/login_image_streamer.json'
-  }
-end
-
-# This method returns the information necessary in order to log in to the Oneview Appliance
-# The three possible ways of declaring the variables are, respectively:
-def login
-  credentials = load_authentication_settings(oneview_options)
+  credentials = load_authentication_settings(options)
   credentials[:hardware_variant] ||= 'C7000'
   credentials
 end
 
 # This method returns the information necessary in order to log in to the Image Streamer Appliance
-# The three possible ways of declaring the variables are, respectively:
 def login_image_streamer
-  load_authentication_settings(image_streamer_options)
-end
-
-def oneview_credentials_set?
-  options = oneview_options
-  return true if ENV[options[:file_env_var]] || ENV[options[:env_var_url]] ||
-                 File.exist?(File.expand_path(Dir.pwd + options[:filename], __FILE__))
-  false
+  options = {
+    type:         'Image Streamer',
+    file_env_var: 'IMAGE_STREAMER_AUTH_FILE',
+    env_var_url:  'IMAGE_STREAMER_URL',
+    filename:     '/login_image_streamer.json'
+  }
+  load_authentication_settings(options)
 end
 
 def load_authentication_settings(options)

--- a/lib/puppet/provider/login.rb
+++ b/lib/puppet/provider/login.rb
@@ -16,16 +16,28 @@
 
 require 'json'
 
-# This method returns the information necessary in order to log in to the Oneview Appliance
-# The three possible ways of declaring the variables are, respectively:
-def login
-  options = {
+def oneview_options
+  {
     type:         'OneView',
     file_env_var: 'ONEVIEW_AUTH_FILE',
     env_var_url:  'ONEVIEW_URL',
     filename:     '/login.json'
   }
-  credentials = load_authentication_settings(options)
+end
+
+def image_streamer_options
+  {
+    type:         'Image Streamer',
+    file_env_var: 'IMAGE_STREAMER_AUTH_FILE',
+    env_var_url:  'IMAGE_STREAMER_URL',
+    filename:     '/login_image_streamer.json'
+  }
+end
+
+# This method returns the information necessary in order to log in to the Oneview Appliance
+# The three possible ways of declaring the variables are, respectively:
+def login
+  credentials = load_authentication_settings(oneview_options)
   credentials[:hardware_variant] ||= 'C7000'
   credentials
 end
@@ -33,13 +45,14 @@ end
 # This method returns the information necessary in order to log in to the Image Streamer Appliance
 # The three possible ways of declaring the variables are, respectively:
 def login_image_streamer
-  options = {
-    type:         'Image Streamer',
-    file_env_var: 'IMAGE_STREAMER_AUTH_FILE',
-    env_var_url:  'IMAGE_STREAMER_URL',
-    filename:     '/login_image_streamer.json'
-  }
-  load_authentication_settings(options)
+  load_authentication_settings(image_streamer_options)
+end
+
+def oneview_credentials_set?
+  options = oneview_options
+  return true if ENV[options[:file_env_var]] || ENV[options[:env_var_url]] ||
+                 File.exist?(File.expand_path(Dir.pwd + options[:filename], __FILE__))
+  false
 end
 
 def load_authentication_settings(options)

--- a/spec/unit/provider/image_streamer_resource_spec.rb
+++ b/spec/unit/provider/image_streamer_resource_spec.rb
@@ -1,0 +1,59 @@
+################################################################################
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+require_relative '../../../lib/puppet/provider/image_streamer_resource.rb'
+
+describe 'image_streamer_resource', unit: true do
+  before(:each) do
+    allow_any_instance_of(Puppet::ImageStreamerResource).to receive(:extract_resource_name).and_return('PlanScript')
+  end
+
+  context '#client when OneView credentials set' do
+    it 'should be created through OneviewSDK::Client' do
+      allow_any_instance_of(Puppet::ImageStreamerResource).to receive(:oneview_credentials_set?).and_return(true)
+      expect_any_instance_of(OneviewSDK::Client).to receive(:new_i3s_client)
+      Puppet::ImageStreamerResource.new
+    end
+
+    it 'should be an instance of OneviewSDK::ImageStreamer::Client' do
+      resource = Puppet::ImageStreamerResource.new
+      allow_any_instance_of(Puppet::ImageStreamerResource).to receive(:oneview_credentials_set?).and_return(true)
+      expect(resource.client).to be_an_instance_of OneviewSDK::ImageStreamer::Client
+    end
+  end
+
+  context '#client when OneView credentials unset' do
+    it 'should not be created through OneviewSDK::Client' do
+      allow_any_instance_of(Puppet::ImageStreamerResource).to receive(:oneview_credentials_set?).and_return(false)
+      expect_any_instance_of(OneviewSDK::Client).not_to receive(:new_i3s_client)
+      Puppet::ImageStreamerResource.new
+    end
+
+    it 'should be an instance of OneviewSDK::ImageStreamer::Client' do
+      resource = Puppet::ImageStreamerResource.new
+      allow_any_instance_of(Puppet::ImageStreamerResource).to receive(:oneview_credentials_set?).and_return(false)
+      expect(resource.client).to be_an_instance_of OneviewSDK::ImageStreamer::Client
+    end
+  end
+
+  context '#ov_resource_type' do
+    it 'should return the right resource type' do
+      resource = Puppet::ImageStreamerResource.new
+      expect(resource.ov_resource_type).to eq(OneviewSDK::ImageStreamer::API300::PlanScript)
+    end
+  end
+end

--- a/spec/unit/provider/login_spec.rb
+++ b/spec/unit/provider/login_spec.rb
@@ -57,71 +57,82 @@ describe 'login', unit: true do
       'spec/support/fixtures/unit/provider/login_no_provider.json'
     end
 
-    it 'should load configuration from file' do
+    before(:each) do
       ENV['ONEVIEW_AUTH_FILE'] = nil
       ENV['ONEVIEW_URL'] = nil
-      allow(Dir).to receive(:pwd).and_return(fixtures_path)
-
-      expect(login).to eq auth_settings
+      allow(Dir).to receive(:pwd).and_return('/an/unavailable/path')
     end
 
-    it 'should load file set in environment variable' do
-      ENV['ONEVIEW_AUTH_FILE'] = config_filename
-      ENV['ONEVIEW_URL'] = nil
+    describe '#oneview_credentials_set?' do
+      it 'should be true when credentials are set in an existing file' do
+        allow(Dir).to receive(:pwd).and_return(fixtures_path)
+        expect(oneview_credentials_set?).to be
+      end
 
-      expect(login).to eq auth_settings
+      it 'should be true when credentials are set through a file defined in an env var' do
+        ENV['ONEVIEW_AUTH_FILE'] = config_filename_no_provider
+        expect(oneview_credentials_set?).to be
+      end
+
+      it 'should be true when credentials are set through env vars' do
+        ENV['ONEVIEW_URL'] = 'https://172.16.100.185'
+        expect(oneview_credentials_set?).to be
+      end
+
+      it 'should be false when no credentials set' do
+        expect(oneview_credentials_set?).not_to be
+      end
     end
 
-    it 'should load file set in environment variable with no provider' do
-      ENV['ONEVIEW_AUTH_FILE'] = config_filename_no_provider
-      ENV['ONEVIEW_URL'] = nil
+    describe '#login' do
+      it 'should load configuration from file' do
+        allow(Dir).to receive(:pwd).and_return(fixtures_path)
+        expect(login).to eq auth_settings
+      end
 
-      expect(login).to eq auth_settings_default_provider
-    end
+      it 'should load file set in environment variable' do
+        ENV['ONEVIEW_AUTH_FILE'] = config_filename
+        expect(login).to eq auth_settings
+      end
 
-    it 'should load settings from environment variables' do
-      ENV['ONEVIEW_AUTH_FILE'] = nil
-      ENV['ONEVIEW_URL'] = 'https://172.16.100.185'
-      ENV['ONEVIEW_SSL_ENABLED'] = 'true'
-      ENV['ONEVIEW_LOG_LEVEL'] = 'debug'
-      ENV['ONEVIEW_API_VERSION'] = '300'
-      ENV['ONEVIEW_TOKEN'] = 'NzA3OTg2NjM2NTk21xd-TkijbSwOjm2AvXDAL4LPG49D9K8u'
-      ENV['ONEVIEW_USER'] = 'administrator'
-      ENV['ONEVIEW_PASSWORD'] = 'secret123'
-      ENV['ONEVIEW_HARDWARE_VARIANT'] = 'Synergy'
+      it 'should load file set in environment variable with no provider' do
+        ENV['ONEVIEW_AUTH_FILE'] = config_filename_no_provider
+        expect(login).to eq auth_settings_default_provider
+      end
 
-      expect(login).to eq auth_settings
-    end
+      it 'should load settings from environment variables' do
+        ENV['ONEVIEW_URL'] = 'https://172.16.100.185'
+        ENV['ONEVIEW_SSL_ENABLED'] = 'true'
+        ENV['ONEVIEW_LOG_LEVEL'] = 'debug'
+        ENV['ONEVIEW_API_VERSION'] = '300'
+        ENV['ONEVIEW_TOKEN'] = 'NzA3OTg2NjM2NTk21xd-TkijbSwOjm2AvXDAL4LPG49D9K8u'
+        ENV['ONEVIEW_USER'] = 'administrator'
+        ENV['ONEVIEW_PASSWORD'] = 'secret123'
+        ENV['ONEVIEW_HARDWARE_VARIANT'] = 'Synergy'
 
-    it 'should load settings from environment variables with default values' do
-      ENV['ONEVIEW_AUTH_FILE'] = nil
-      ENV['ONEVIEW_URL'] = 'https://172.16.100.185'
-      ENV['ONEVIEW_SSL_ENABLED'] = 'false'
-      ENV['ONEVIEW_LOG_LEVEL'] = nil
-      ENV['ONEVIEW_API_VERSION'] = nil
-      ENV['ONEVIEW_TOKEN'] = nil
-      ENV['ONEVIEW_USER'] = nil
-      ENV['ONEVIEW_PASSWORD'] = nil
-      ENV['ONEVIEW_HARDWARE_VARIANT'] = nil
+        expect(login).to eq auth_settings
+      end
 
-      auth_settings = {
-        url:               'https://172.16.100.185',
-        ssl_enabled:       false,
-        log_level:         'info',
-        api_version:       200,
-        token:             nil,
-        user:              nil,
-        password:          nil,
-        hardware_variant:  'C7000'
-      }
-      expect(login).to eq auth_settings
-    end
+      it 'should load settings from environment variables with default values' do
+        ENV['ONEVIEW_URL'] = 'https://172.16.100.185'
+        ENV['ONEVIEW_SSL_ENABLED'] = 'false'
 
-    it 'should raise error when authentication settings undefined' do
-      ENV['ONEVIEW_AUTH_FILE'] = nil
-      ENV['ONEVIEW_URL'] = nil
+        auth_settings = {
+          url:               'https://172.16.100.185',
+          ssl_enabled:       false,
+          log_level:         'info',
+          api_version:       200,
+          token:             nil,
+          user:              nil,
+          password:          nil,
+          hardware_variant:  'C7000'
+        }
+        expect(login).to eq auth_settings
+      end
 
-      expect { login }.to raise_error(/The OneView credentials could not be set. Please check the documentation for more information./)
+      it 'should raise error when authentication settings undefined' do
+        expect { login }.to raise_error(/The OneView credentials could not be set. Please check the documentation for more information./)
+      end
     end
   end
 
@@ -136,60 +147,56 @@ describe 'login', unit: true do
       }
     end
 
+    before(:each) do
+      ENV['IMAGE_STREAMER_AUTH_FILE'] = nil
+      ENV['IMAGE_STREAMER_URL'] = nil
+      allow(Dir).to receive(:pwd).and_return('/an/unavailable/path')
+    end
+
     let(:config_filename) do
       'spec/support/fixtures/unit/provider/login_image_streamer.json'
     end
 
-    it 'should load configuration from file' do
-      ENV['IMAGE_STREAMER_AUTH_FILE'] = nil
-      ENV['IMAGE_STREAMER_URL'] = nil
-      allow(Dir).to receive(:pwd).and_return(fixtures_path)
+    describe '#login_image_streamer' do
+      it 'should load configuration from file' do
+        allow(Dir).to receive(:pwd).and_return(fixtures_path)
 
-      expect(login_image_streamer).to eq auth_settings
-    end
+        expect(login_image_streamer).to eq auth_settings
+      end
 
-    it 'should load file set in environment variable' do
-      ENV['IMAGE_STREAMER_AUTH_FILE'] = config_filename
-      ENV['IMAGE_STREAMER_URL'] = nil
+      it 'should load file set in environment variable' do
+        ENV['IMAGE_STREAMER_AUTH_FILE'] = config_filename
+        expect(login_image_streamer).to eq auth_settings
+      end
 
-      expect(login_image_streamer).to eq auth_settings
-    end
+      it 'should load settings from environment variables' do
+        ENV['IMAGE_STREAMER_URL'] = 'https://172.16.100.182'
+        ENV['IMAGE_STREAMER_SSL_ENABLED'] = 'true'
+        ENV['IMAGE_STREAMER_LOG_LEVEL'] = 'debug'
+        ENV['IMAGE_STREAMER_API_VERSION'] = '300'
+        ENV['IMAGE_STREAMER_TOKEN'] = 'NzA3OTg2NjM2NTk21xd-TkijbSwOjm2AvXDAL4LPG49D9K8u'
 
-    it 'should load settings from environment variables' do
-      ENV['IMAGE_STREAMER_AUTH_FILE'] = nil
-      ENV['IMAGE_STREAMER_URL'] = 'https://172.16.100.182'
-      ENV['IMAGE_STREAMER_SSL_ENABLED'] = 'true'
-      ENV['IMAGE_STREAMER_LOG_LEVEL'] = 'debug'
-      ENV['IMAGE_STREAMER_API_VERSION'] = '300'
-      ENV['IMAGE_STREAMER_TOKEN'] = 'NzA3OTg2NjM2NTk21xd-TkijbSwOjm2AvXDAL4LPG49D9K8u'
+        expect(login_image_streamer).to eq auth_settings
+      end
 
-      expect(login_image_streamer).to eq auth_settings
-    end
+      it 'should load settings from environment variables with default values' do
+        ENV['IMAGE_STREAMER_URL'] = 'https://172.16.100.182'
+        ENV['IMAGE_STREAMER_SSL_ENABLED'] = 'false'
 
-    it 'should load settings from environment variables with default values' do
-      ENV['IMAGE_STREAMER_AUTH_FILE'] = nil
-      ENV['IMAGE_STREAMER_URL'] = 'https://172.16.100.182'
-      ENV['IMAGE_STREAMER_SSL_ENABLED'] = 'false'
-      ENV['IMAGE_STREAMER_LOG_LEVEL'] = nil
-      ENV['IMAGE_STREAMER_API_VERSION'] = nil
-      ENV['IMAGE_STREAMER_TOKEN'] = nil
+        auth_settings = {
+          url:               'https://172.16.100.182',
+          ssl_enabled:       false,
+          log_level:         'info',
+          api_version:       300,
+          token:             nil
+        }
+        expect(login_image_streamer).to eq auth_settings
+      end
 
-      auth_settings = {
-        url:               'https://172.16.100.182',
-        ssl_enabled:       false,
-        log_level:         'info',
-        api_version:       300,
-        token:             nil
-      }
-      expect(login_image_streamer).to eq auth_settings
-    end
-
-    it 'should raise error when authentication settings undefined' do
-      ENV['IMAGE_STREAMER_AUTH_FILE'] = nil
-      ENV['IMAGE_STREAMER_URL'] = nil
-
-      error_message = /The Image Streamer credentials could not be set. Please check the documentation for more information./
-      expect { login_image_streamer }.to raise_error(error_message)
+      it 'should raise error when authentication settings undefined' do
+        error_message = /The Image Streamer credentials could not be set. Please check the documentation for more information./
+        expect { login_image_streamer }.to raise_error(error_message)
+      end
     end
   end
 end

--- a/spec/unit/provider/login_spec.rb
+++ b/spec/unit/provider/login_spec.rb
@@ -63,27 +63,6 @@ describe 'login', unit: true do
       allow(Dir).to receive(:pwd).and_return('/an/unavailable/path')
     end
 
-    describe '#oneview_credentials_set?' do
-      it 'should be true when credentials are set in an existing file' do
-        allow(Dir).to receive(:pwd).and_return(fixtures_path)
-        expect(oneview_credentials_set?).to be
-      end
-
-      it 'should be true when credentials are set through a file defined in an env var' do
-        ENV['ONEVIEW_AUTH_FILE'] = config_filename_no_provider
-        expect(oneview_credentials_set?).to be
-      end
-
-      it 'should be true when credentials are set through env vars' do
-        ENV['ONEVIEW_URL'] = 'https://172.16.100.185'
-        expect(oneview_credentials_set?).to be
-      end
-
-      it 'should be false when no credentials set' do
-        expect(oneview_credentials_set?).not_to be
-      end
-    end
-
     describe '#login' do
       it 'should load configuration from file' do
         allow(Dir).to receive(:pwd).and_return(fixtures_path)


### PR DESCRIPTION
### Description
Simplify login into i3s
Does not require a specific token on i3s auth settings when the OneView credentials are set.

### Issues Resolved
#116 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
