### PR TITLE
Enable run unit tests with no auth files/env vars set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Image_streamer_plan_script
 
 #### Bug fixes & Enhancements:
+- [#103](https://github.com/HewlettPackard/oneview-puppet/issues/103) Unit tests should not require auth files/environment variables from the user
 - [#105](https://github.com/HewlettPackard/oneview-puppet/issues/105) Create or update uplink sets through logical interconnect groups
 - [#119](https://github.com/HewlettPackard/oneview-puppet/issues/119) Update unit tests to match updated remove_extra_unmanaged_volume from oneview-ruby-sdk
 

--- a/spec/integration/provider/oneview_enclosure_spec.rb
+++ b/spec/integration/provider/oneview_enclosure_spec.rb
@@ -22,8 +22,8 @@ require File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/puppet/
 
 provider_class = Puppet::Type.type(:oneview_enclosure).provider(:c7000)
 enclosure_ip = login[:enclosure_ip] || '172.18.1.13'
-enclosure_username = login[:enclosure_username] || dcs
-enclosure_password = login[:enclosure_password] || dcs
+enclosure_username = login[:enclosure_username] || 'dcs'
+enclosure_password = login[:enclosure_password] || 'dcs'
 enclosure_group = login[:enclosure_group] || 'Puppet Enc Group Test'
 
 describe provider_class do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,6 +86,7 @@ RSpec.configure do |config|
 
   if config.filter_manager.inclusions.rules[:unit]
     ENV['IMAGE_STREAMER_AUTH_FILE'] = 'spec/support/fixtures/unit/provider/login_image_streamer.json'
+    ENV['ONEVIEW_AUTH_FILE'] = 'spec/support/fixtures/unit/provider/login_no_provider.json'
   end
 
   config.before(:each) do


### PR DESCRIPTION
### Description
Unit tests should not require auth files/environment variables from the user.

### Issues Resolved
#103 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
