### PR TITLE
Fix uri_parsing for Image Streamer resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - [#105](https://github.com/HewlettPackard/oneview-puppet/issues/105) Create or update uplink sets through logical interconnect groups
 - [#119](https://github.com/HewlettPackard/oneview-puppet/issues/119) Update unit tests to match updated remove_extra_unmanaged_volume from oneview-ruby-sdk
 - [#116](https://github.com/HewlettPackard/oneview-puppet/issues/116) Simplify login to i3s
+- [#121](https://github.com/HewlettPackard/oneview-puppet/issues/121) Deployment Plan and Golden Image should use the default uri parser
+- [#122](https://github.com/HewlettPackard/oneview-puppet/issues/122) Uri_parsing should support upper case for uri
 
 # 2.1.0 (2017-02-03)
 ### Version highlights:

--- a/lib/puppet/provider/image_streamer_deployment_plan/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_deployment_plan/image_streamer.rb
@@ -23,24 +23,6 @@ Puppet::Type.type(:image_streamer_deployment_plan).provide :image_streamer, pare
 
   def exists?
     super
-    parse_build_plan
-    parse_golden_image
     @resourcetype.find_by(@client, @data).any?
-  end
-
-  def parse_build_plan
-    return unless @data['oeBuildPlanURI'] && !@data['oeBuildPlanURI'].include?('/rest/')
-    build_plan_class = OneviewSDK::ImageStreamer.resource_named('BuildPlan', @client.api_version)
-    resource = build_plan_class.find_by(@client, name: @data['oeBuildPlanURI'])
-    raise 'Build Plan has not been found in the Appliance.' if resource.empty?
-    @data['oeBuildPlanURI'] = resource.first['uri']
-  end
-
-  def parse_golden_image
-    return unless @data['goldenImageURI'] && !@data['goldenImageURI'].include?('/rest/')
-    golden_image_class = OneviewSDK::ImageStreamer.resource_named('GoldenImage', @client.api_version)
-    resource = golden_image_class.find_by(@client, name: @data['goldenImageURI'])
-    raise 'Golden Image has not been found in the Appliance.' if resource.empty?
-    @data['goldenImageURI'] = resource.first['uri']
   end
 end

--- a/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
@@ -24,7 +24,6 @@ Puppet::Type::Image_streamer_golden_image.provide :image_streamer, parent: Puppe
   def exists?
     super([nil, :found, :download_details_archive, :download])
     @golden_image_path = @data.delete('golden_image_path')
-    uri_getter
     !@resourcetype.find_by(@client, @data).empty?
   end
 
@@ -47,13 +46,5 @@ Puppet::Type::Image_streamer_golden_image.provide :image_streamer, parent: Puppe
     golden_image = get_single_resource_instance
     golden_image.download(download_path)
     true
-  end
-
-  def uri_getter
-    return unless @data['osVolumeURI'] && !@data['osVolumeURI'].include?('/rest/')
-    os_volume_classname = OneviewSDK::ImageStreamer.resource_named('OSVolume', @client.api_version)
-    resource = os_volume_classname.find_by(@client, name: @data['osVolumeURI'])
-    raise 'OSVolume has not been found in the Appliance.' if resource.empty?
-    @data['osVolumeURI'] = resource.first['uri']
   end
 end

--- a/lib/puppet/provider/uri_parsing.rb
+++ b/lib/puppet/provider/uri_parsing.rb
@@ -28,8 +28,8 @@ def uri_recursive_hash(data)
     # in case the key is either an array or hash
     hash_array_check(data[key])
     # next if -the uri is already declared- or -the parameter name does not require a uri- or -value is nil-
-    next if value.to_s[0..6].include?('/rest/') || !((key.to_s.include? 'Uri') || (key.to_s == 'uri')) || value.to_s == 'nil' ||
-            value.nil? || value.to_s == 'null' || exception_to_be_treated_within_provider(key)
+    next if value.to_s[0..6].include?('/rest/') || !(key.to_s.include?('Uri') || key.to_s == 'uri' || key.to_s.end_with?('URI')) ||
+            value.nil? || %w(null nil).include?(value.to_s) || exception_to_be_treated_within_provider(key)
     data[key] = get_uri(key)
   end
 end
@@ -56,7 +56,8 @@ end
 def special_resources_check(key)
   special_resources = %w(resourceUri actualNetworkUri expectedNetworkUri uri firmwareBaselineUri actualNetworkSanUri dependentResourceUri
                          sspUri associatedUplinkSetUri associatedTaskUri parentTaskUri snapshotPoolUri volumeStoragePoolUri
-                         volumeStorageSystemUri baselineUri mountUri nativeNetworkUri enclosureUris)
+                         volumeStorageSystemUri baselineUri mountUri nativeNetworkUri enclosureUris oeBuildPlanURI osVolumeURI
+                         osDeploymentPlanUri)
   return key unless special_resources.include?(key)
   # Assigns the correct key to be used with find_by, and adds 'Uri' to the end of the key
   # to make it compatible with the get_class method which will be called after this
@@ -68,6 +69,7 @@ end
 def special_resources_assign(key)
   return generic_resource_fixer if %w(resourceUri actualNetworkUri expectedNetworkUri uri mountUri).include?(key)
   case key
+  # OneView resources
   when 'firmwareBaselineUri', 'sspUri', 'baselineUri' then 'FirmwareDriver'
   when 'actualNetworkSanUri' then 'ManagedSAN'
   when 'dependentResourceUri' then 'LogicalInterconnect'
@@ -77,6 +79,10 @@ def special_resources_assign(key)
   when 'parentTaskUri', 'associatedTaskUri' then 'Task'
   when 'nativeNetworkUri' then 'EthernetNetwork'
   when 'enclosureUris' then 'Enclosure'
+  when 'osDeploymentPlanUri' then 'OSDeploymentPlan'
+  # Image Streamer resources
+  when 'oeBuildPlanURI' then 'BuildPlan'
+  when 'osVolumeURI' then 'OSVolume'
   end
 end
 

--- a/spec/unit/provider/uri_parsing_spec.rb
+++ b/spec/unit/provider/uri_parsing_spec.rb
@@ -18,6 +18,12 @@ require 'spec_helper'
 require_relative '../../../lib/puppet/provider/uri_parsing.rb'
 
 describe 'uri_parsing', unit: true do
+  let(:names_list) { %w(name1 name2) }
+
+  let(:name) { 'name1' }
+
+  let(:fake_uri) { '/rest/fakeuri' }
+
   describe 'given Image Streamer resources' do
     include_context 'shared context Image Streamer'
 
@@ -36,9 +42,14 @@ describe 'uri_parsing', unit: true do
       allow(golden_image_type).to receive(:find_by).with(anything, name: golden_image_name).and_return([golden_image])
     end
 
-    it 'should replace resource name by uri' do
+    it 'should replace resource name by uri when key contains Uri' do
       data = { 'goldenImageUri' => golden_image_name }
       expect(uri_validation(data)).to eq 'goldenImageUri' => golden_image_uri
+    end
+
+    it 'should replace resource name by uri when key contains URI' do
+      data = { 'goldenImageURI' => golden_image_name }
+      expect(uri_validation(data)).to eq 'goldenImageURI' => golden_image_uri
     end
 
     it 'should replace resource name by uri using recursion' do
@@ -64,6 +75,11 @@ describe 'uri_parsing', unit: true do
       expect(get_class('goldenImageUri')).to eq OneviewSDK::ImageStreamer::API300::GoldenImage
     end
 
+    it 'should do nothing when key contains uris' do
+      data = { 'golden_image_uris' => [golden_image_name] }
+      expect(uri_validation(data)).to eq 'golden_image_uris' => [golden_image_name]
+    end
+
     it 'should raise error when class is not found' do
       expect { get_class('invalidUri') }.to raise_error(NameError)
     end
@@ -86,7 +102,12 @@ describe 'uri_parsing', unit: true do
       allow(OneviewSDK::API300::C7000::Enclosure).to receive(:find_by).with(anything, name: 'Enclosure Name').and_return([enclosure])
     end
 
-    it 'should replace resource name by uri' do
+    it 'should replace resource name by uri when key contains Uri' do
+      data = { 'enclosureUri' => enclosure_name }
+      expect(uri_validation(data)).to eq 'enclosureUri' => enclosure_uri
+    end
+
+    it 'should replace resource name by uri when key contains URI' do
       data = { 'enclosureUri' => enclosure_name }
       expect(uri_validation(data)).to eq 'enclosureUri' => enclosure_uri
     end
@@ -112,6 +133,11 @@ describe 'uri_parsing', unit: true do
       expect(get_class('enclosureUri')).to eq OneviewSDK::API300::C7000::Enclosure
     end
 
+    it 'should do nothing when key contains uris' do
+      data = { 'enclosure_uris' => [enclosure_name] }
+      expect(uri_validation(data)).to eq 'enclosure_uris' => [enclosure_name]
+    end
+
     it 'should raise error when class is not found' do
       expect { get_class('invalidUri') }.to raise_error(NameError)
     end
@@ -134,9 +160,14 @@ describe 'uri_parsing', unit: true do
       allow(OneviewSDK::API200::Enclosure).to receive(:find_by).with(anything, name: 'Enclosure Name').and_return([enclosure])
     end
 
-    it 'should replace resource name by uri' do
-      data = { 'enclosureUri' => enclosure_name }
+    it 'should replace resource name by uri when key contains Uri' do
+      data = { 'enclosureUri' => enclosure_uri }
       expect(uri_validation(data)).to eq 'enclosureUri' => enclosure_uri
+    end
+
+    it 'should replace resource name by uri when key contains URI' do
+      data = { 'enclosureURI' => enclosure_name }
+      expect(uri_validation(data)).to eq 'enclosureURI' => enclosure_uri
     end
 
     it 'should replace resource name by uri using recursion' do
@@ -160,8 +191,214 @@ describe 'uri_parsing', unit: true do
       expect(get_class('enclosureUri')).to eq OneviewSDK::API200::Enclosure
     end
 
+    it 'should do nothing when key contains uris' do
+      data = { 'enclosure_uris' => [enclosure_name] }
+      expect(uri_validation(data)).to eq 'enclosure_uris' => [enclosure_name]
+    end
+
     it 'should raise error when class is not found' do
       expect { get_class('invalidUri') }.to raise_error(NameError)
+    end
+  end
+
+  describe 'given the value is already an URI or it is null' do
+    include_context 'shared context'
+
+    it 'should do nothing when value is nil' do
+      data = { 'enclosureUri' => nil }
+      expect(uri_validation(data)).to eq 'enclosureUri' => nil
+    end
+
+    it 'should do nothing when value is a string nil' do
+      data = { 'enclosureUri' => 'nil' }
+      expect(uri_validation(data)).to eq 'enclosureUri' => 'nil'
+    end
+
+    it 'should do nothing when value is a string null' do
+      data = { 'enclosureUri' => 'null' }
+      expect(uri_validation(data)).to eq 'enclosureUri' => 'null'
+    end
+
+    it 'should do nothing when value is already an URI' do
+      data = { 'enclosureUri' => fake_uri }
+      expect(uri_validation(data)).to eq 'enclosureUri' => fake_uri
+    end
+  end
+
+  describe 'given the OneView special resources managed by the provider' do
+    include_context 'shared context'
+
+    it 'should do nothing when key is networkUris' do
+      data = { 'networkUris' => names_list }
+      expect(uri_validation(data)).to eq 'networkUris' => names_list
+    end
+
+    it 'should do nothing when key is networkUri' do
+      data = { 'networkUri' => name }
+      expect(uri_validation(data)).to eq 'networkUri' => name
+    end
+
+    it 'should do nothing when key is hotfixUris' do
+      data = { 'hotfixUris' => names_list }
+      expect(uri_validation(data)).to eq 'hotfixUris' => names_list
+    end
+
+    it 'should do nothing when key is fcNetworkUris' do
+      data = { 'fcNetworkUris' => names_list }
+      expect(uri_validation(data)).to eq 'fcNetworkUris' => names_list
+    end
+
+    it 'should do nothing when key is fcoeNetworkUris' do
+      data = { 'fcoeNetworkUris' => names_list }
+      expect(uri_validation(data)).to eq 'fcoeNetworkUris' => names_list
+    end
+
+    it 'should do nothing when key is networkUri' do
+      data = { 'connectionUri' => name }
+      expect(uri_validation(data)).to eq 'connectionUri' => name
+    end
+
+    it 'should do nothing when key is providerUri' do
+      data = { 'providerUri' => name }
+      expect(uri_validation(data)).to eq 'providerUri' => name
+    end
+
+    it 'should do nothing when key is permittedInterconnectTypeUri' do
+      data = { 'permittedInterconnectTypeUri' => name }
+      expect(uri_validation(data)).to eq 'permittedInterconnectTypeUri' => name
+    end
+
+    it 'should do nothing when key is permittedSwitchTypeUri' do
+      data = { 'permittedSwitchTypeUri' => name }
+      expect(uri_validation(data)).to eq 'permittedSwitchTypeUri' => name
+    end
+
+    it 'should do nothing when key is internalNetworkUris' do
+      data = { 'internalNetworkUris' =>  names_list }
+      expect(uri_validation(data)).to eq 'internalNetworkUris' => names_list
+    end
+  end
+
+  describe 'given the OneView special resources managed by uri_parsing' do
+    include_context 'shared context'
+
+    let(:resource_variant) { 'C7000' }
+
+    before(:each) do
+      driver = OneviewSDK::API300::C7000::FirmwareDriver.new(@client, 'name' => name, 'uri' => '/rest/firmware-drivers/fake-id')
+      allow(OneviewSDK::API300::C7000::FirmwareDriver).to receive(:find_by).with(anything, name: name).and_return([driver])
+
+      storage_pool = OneviewSDK::API300::C7000::StoragePool.new(@client, 'name' => name, 'uri' => '/rest/storage-pools/fake-id')
+      allow(OneviewSDK::API300::C7000::StoragePool).to receive(:find_by).with(anything, name: name).and_return([storage_pool])
+    end
+
+    it 'should replace FirmwareDriver name by uri when key is firmwareBaselineUri' do
+      data = { 'firmwareBaselineUri' => name }
+      expect(uri_validation(data)).to eq 'firmwareBaselineUri' => '/rest/firmware-drivers/fake-id'
+    end
+
+    it 'should replace FirmwareDriver name by uri when key is sspUri' do
+      data = { 'sspUri' => name }
+      expect(uri_validation(data)).to eq 'sspUri' => '/rest/firmware-drivers/fake-id'
+    end
+
+    it 'should replace FirmwareDriver name by uri when key is baselineUri' do
+      data = { 'baselineUri' => name }
+      expect(uri_validation(data)).to eq 'baselineUri' => '/rest/firmware-drivers/fake-id'
+    end
+
+    it 'should replace ManagedSAN name by uri when key is actualNetworkSanUri' do
+      san = OneviewSDK::API300::C7000::ManagedSAN.new(@client, 'name' => name, 'uri' => '/rest/fc-sans/managed-sans/fake-id')
+      allow(OneviewSDK::API300::C7000::ManagedSAN).to receive(:find_by).with(anything, name: name).and_return([san])
+
+      data = { 'actualNetworkSanUri' => name }
+      expect(uri_validation(data)).to eq 'actualNetworkSanUri' => '/rest/fc-sans/managed-sans/fake-id'
+    end
+
+    it 'should replace LogicalInterconnect name by uri when key is dependentResourceUri' do
+      uri = '/rest/logical-interconnects/fake-id'
+      log_interc = OneviewSDK::API300::C7000::LogicalInterconnect.new(@client, 'name' => name, 'uri' => uri)
+      allow(OneviewSDK::API300::C7000::LogicalInterconnect).to receive(:find_by).with(anything, name: name).and_return([log_interc])
+
+      data = { 'dependentResourceUri' => name }
+      expect(uri_validation(data)).to eq 'dependentResourceUri' => '/rest/logical-interconnects/fake-id'
+    end
+
+    it 'should replace StoragePool name by uri when key is snapshotPoolUri' do
+      data = { 'snapshotPoolUri' => name }
+      expect(uri_validation(data)).to eq 'snapshotPoolUri' => '/rest/storage-pools/fake-id'
+    end
+
+    it 'should replace StoragePool name by uri when key is volumeStoragePoolUri' do
+      data = { 'volumeStoragePoolUri' => name }
+      expect(uri_validation(data)).to eq 'volumeStoragePoolUri' => '/rest/storage-pools/fake-id'
+    end
+
+    it 'should replace StorageSystem name by uri when key is volumeStorageSystemUri' do
+      storage_system = OneviewSDK::API300::C7000::StorageSystem.new(@client, 'name' => name, 'uri' => '/rest/storage-systems/fake-id')
+      allow(OneviewSDK::API300::C7000::StorageSystem).to receive(:find_by).with(anything, name: name).and_return([storage_system])
+
+      data = { 'volumeStorageSystemUri' => name }
+      expect(uri_validation(data)).to eq 'volumeStorageSystemUri' => '/rest/storage-systems/fake-id'
+    end
+
+    it 'should replace UplinkSet name by uri when key is associatedUplinkSetUri' do
+      uplink_set = OneviewSDK::API300::C7000::UplinkSet.new(@client, 'name' => name, 'uri' => '/rest/uplink-sets/fake-id')
+      allow(OneviewSDK::API300::C7000::UplinkSet).to receive(:find_by).with(anything, name: name).and_return([uplink_set])
+
+      data = { 'associatedUplinkSetUri' => name }
+      expect(uri_validation(data)).to eq 'associatedUplinkSetUri' => '/rest/uplink-sets/fake-id'
+    end
+
+    it 'should replace EthernetNetwork name by uri when key is nativeNetworkUri' do
+      eth_network = OneviewSDK::API300::C7000::EthernetNetwork.new(@client, 'name' => name, 'uri' => '/rest/ethernet-networks/fake-id')
+      allow(OneviewSDK::API300::C7000::EthernetNetwork).to receive(:find_by).with(anything, name: name).and_return([eth_network])
+
+      data = { 'nativeNetworkUri' => name }
+      expect(uri_validation(data)).to eq 'nativeNetworkUri' => '/rest/ethernet-networks/fake-id'
+    end
+
+    it 'should replace Enclosure name by uri when key is enclosureUris' do
+      enclosure = OneviewSDK::API300::C7000::Enclosure.new(@client, 'name' => name, 'uri' => '/rest/enclosures/fake-id')
+      allow(OneviewSDK::API300::C7000::Enclosure).to receive(:find_by).with(anything, name: name).and_return([enclosure])
+
+      data = { 'enclosureUris' => name }
+      expect(uri_validation(data)).to eq 'enclosureUris' => '/rest/enclosures/fake-id'
+    end
+  end
+
+  describe 'given the OneView Synergy special resources managed by uri_parsing' do
+    include_context 'shared context'
+
+    let(:resource_variant) { 'Synergy' }
+
+    it 'should replace OS Deployment Plan name by uri when key is osDeploymentPlanUri' do
+      uri = '/rest/os-deployment-plans/fake-id'
+      deployment_plan = OneviewSDK::API300::Synergy::OSDeploymentPlan.new(@client, 'name' => name, 'uri' => uri)
+      allow(OneviewSDK::API300::Synergy::OSDeploymentPlan).to receive(:find_by).with(anything, name: name).and_return([deployment_plan])
+
+      data = { 'osDeploymentPlanUri' => name }
+      expect(uri_validation(data)).to eq 'osDeploymentPlanUri' => uri
+    end
+  end
+
+  describe 'given the ImageStreamer special resources managed by uri_parsing' do
+    include_context 'shared context Image Streamer'
+
+    it 'should replace BuildPlan name by uri when key is oeBuildPlanURI' do
+      build_plan = OneviewSDK::ImageStreamer::API300::BuildPlan.new(@client, 'name' => name, 'uri' => '/rest/build-plans/fake-id')
+      allow(OneviewSDK::ImageStreamer::API300::BuildPlan).to receive(:find_by).with(anything, name: name).and_return([build_plan])
+
+      data = { 'oeBuildPlanURI' => name }
+      expect(uri_validation(data)).to eq 'oeBuildPlanURI' => '/rest/build-plans/fake-id'
+    end
+
+    it 'should replace OSVolume name by uri when key is osVolumeURI' do
+      build_plan = OneviewSDK::ImageStreamer::API300::OSVolume.new(@client, 'name' => name, 'uri' => '/rest/os-volumes/fake-id')
+      allow(OneviewSDK::ImageStreamer::API300::OSVolume).to receive(:find_by).with(anything, name: name).and_return([build_plan])
+
+      data = { 'osVolumeURI' => name }
+      expect(uri_validation(data)).to eq 'osVolumeURI' => '/rest/os-volumes/fake-id'
     end
   end
 end


### PR DESCRIPTION
### Description
- Changes the uri_parsing method, adding special assignment when the key is:
 1. osDeploymentPlanUri (recently added on the ruby-sdk)
 2. oeBuildPlanURI
 3. osVolumeURI

- Increases the unit testing coverage

### Issues Resolved
#121 and #122 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
