### PR TITLE
Allow set a timeout for the Golden Image upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#116](https://github.com/HewlettPackard/oneview-puppet/issues/116) Simplify login to i3s
 - [#121](https://github.com/HewlettPackard/oneview-puppet/issues/121) Deployment Plan and Golden Image should use the default uri parser
 - [#122](https://github.com/HewlettPackard/oneview-puppet/issues/122) Uri_parsing should support upper case for uri
+- [#133](https://github.com/HewlettPackard/oneview-puppet/issues/133) Allow set a timeout for Image_streamer_golden_image upload
 
 # 2.1.0 (2017-02-03)
 ### Version highlights:

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -582,14 +582,14 @@ Example file: [volume_template.pp](examples/volume_template.pp)
 
 This resource provides the following ensurable methods for managing Artifact Bundles on the Image Streamer appliance:
 
-* `present` - Adds, uploads, or updates an artifact bundle resource based upon the attributes specified within `data`.
+* `present` - Adds, uploads, or updates an artifact bundle resource based upon the attributes specified within `data`. If you are adding an artifact bundle zip file, you can set a `timeout` (in seconds) within the `data`.
 * `found` - Searches for `image_streamer_artifact_bundle` resources on the appliance (with or without specific filters) and prints the name and uri of matches to the standard output.
 * `extract` - Extracts an artifact bundle and creates the artifacts on the appliance.
 * `download` - Downloads the content of an artifact bundle to a local drive.
 * `get_backups` - Gets information about the backups.
 * `extract_backup` - Extracts the existing backup bundle on the appliance and creates all the artifacts. :exclamation: If there are any artifacts existing, they will be removed before the extract operation.
 * `create_backup` - Creates a backup bundle with all the artifacts present on the appliance. At any given point only one backup bundle will exist on the appliance.
-* `create_backup_from_file` - Uploads a backup bundle from a local drive and extracts all the artifacts present in the uploaded file. :exclamation: If there are any artifacts existing, they will be removed before the extract operation.
+* `create_backup_from_file` - Uploads a backup bundle from a local drive and extracts all the artifacts present in the uploaded file. You can set a `timeout` (in seconds) within the `data`. :exclamation: If there are any artifacts existing, they will be removed before the extract operation.
 * `download_backup` - Downloads a backup.
 * `absent` - Deletes an Artifact Bundle.
 
@@ -629,7 +629,7 @@ Example file: [deployment_group.pp](examples/image_streamer/deployment_group.pp)
 
 This resource provides the following ensurable methods for managing Golden Images on the Image Streamer appliance:
 
-* `present` - Adds or updates a golden resource based upon the attributes specified within `data`.
+* `present` - Adds or updates a golden resource based upon the attributes specified within `data`. If you are adding a golden image zip file, you can set a `timeout` (in seconds) within the `data`.
 * `found` - Searches for `image_streamer_golden_image` resources on the appliance (with or without specific filters) and prints the name and uri of matches to the standard output.
 * `download` - Downloads the content of a golden image.
 * `download_details_archive` - Downloads the details of the golden image capture logs which has been archived.

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -582,14 +582,14 @@ Example file: [volume_template.pp](examples/volume_template.pp)
 
 This resource provides the following ensurable methods for managing Artifact Bundles on the Image Streamer appliance:
 
-* `present` - Adds, uploads, or updates an artifact bundle resource based upon the attributes specified within `data`. If you are adding an artifact bundle zip file, you can set a `timeout` (in seconds) within the `data`.
+* `present` - Adds, uploads, or updates an artifact bundle resource based upon the attributes specified within `data`. The upload operation supports a `timeout` (in seconds) specified within the data.
 * `found` - Searches for `image_streamer_artifact_bundle` resources on the appliance (with or without specific filters) and prints the name and uri of matches to the standard output.
 * `extract` - Extracts an artifact bundle and creates the artifacts on the appliance.
 * `download` - Downloads the content of an artifact bundle to a local drive.
 * `get_backups` - Gets information about the backups.
 * `extract_backup` - Extracts the existing backup bundle on the appliance and creates all the artifacts. :exclamation: If there are any artifacts existing, they will be removed before the extract operation.
 * `create_backup` - Creates a backup bundle with all the artifacts present on the appliance. At any given point only one backup bundle will exist on the appliance.
-* `create_backup_from_file` - Uploads a backup bundle from a local drive and extracts all the artifacts present in the uploaded file. You can set a `timeout` (in seconds) within the `data`. :exclamation: If there are any artifacts existing, they will be removed before the extract operation.
+* `create_backup_from_file` - Uploads a backup bundle from a local drive and extracts all the artifacts present in the uploaded file. The upload operation supports a `timeout` (in seconds) specified within the `data`. :exclamation: If there are any artifacts existing, they will be removed before the extract operation.
 * `download_backup` - Downloads a backup.
 * `absent` - Deletes an Artifact Bundle.
 
@@ -629,7 +629,7 @@ Example file: [deployment_group.pp](examples/image_streamer/deployment_group.pp)
 
 This resource provides the following ensurable methods for managing Golden Images on the Image Streamer appliance:
 
-* `present` - Adds or updates a golden resource based upon the attributes specified within `data`. If you are adding a golden image zip file, you can set a `timeout` (in seconds) within the `data`.
+* `present` - Adds or updates a golden resource based upon the attributes specified within `data`. The upload operation supports a `timeout` (in seconds) specified within the `data`.
 * `found` - Searches for `image_streamer_golden_image` resources on the appliance (with or without specific filters) and prints the name and uri of matches to the standard output.
 * `download` - Downloads the content of a golden image.
 * `download_details_archive` - Downloads the details of the golden image capture logs which has been archived.

--- a/examples/image_streamer/artifact_bundle.pp
+++ b/examples/image_streamer/artifact_bundle.pp
@@ -50,7 +50,7 @@ image_streamer_artifact_bundle{'artifact_bundle_4':
   data   => {
     name                 => 'Artifact_Bundle_2_Puppet',
     artifact_bundle_path => 'examples/image_streamer/artifact_bundle.zip',  # can be either an absolute or relative path
-    timeout              => 3600  # you can set a timeout (in seconds) for the upload
+    timeout              => 3600  # optionally sets a timeout (in seconds) for the upload
   }
 }
 
@@ -112,7 +112,7 @@ image_streamer_artifact_bundle{'artifact_bundle_11':
   data    => {
     deploymentGroupUri => 'OSDS',
     backup_upload_path => 'examples/image_streamer/ci-backup2017-03-01T17_40_31.628Z.zip',  # can be either an absolute or relative path
-    timeout            => 3600  # you can set a timeout (in seconds) for the upload
+    timeout            => 3600  # optionally sets a timeout (in seconds) for the upload
   }
 }
 

--- a/examples/image_streamer/artifact_bundle.pp
+++ b/examples/image_streamer/artifact_bundle.pp
@@ -50,7 +50,7 @@ image_streamer_artifact_bundle{'artifact_bundle_4':
   data   => {
     name                 => 'Artifact_Bundle_2_Puppet',
     artifact_bundle_path => 'examples/image_streamer/artifact_bundle.zip',  # can be either an absolute or relative path
-    timeout              => 3600
+    timeout              => 3600  # you can set a timeout (in seconds) for the upload
   }
 }
 
@@ -112,7 +112,7 @@ image_streamer_artifact_bundle{'artifact_bundle_11':
   data    => {
     deploymentGroupUri => 'OSDS',
     backup_upload_path => 'examples/image_streamer/ci-backup2017-03-01T17_40_31.628Z.zip',  # can be either an absolute or relative path
-    timeout            => 3600
+    timeout            => 3600  # you can set a timeout (in seconds) for the upload
   }
 }
 

--- a/examples/image_streamer/golden_image.pp
+++ b/examples/image_streamer/golden_image.pp
@@ -32,7 +32,8 @@ image_streamer_golden_image{'golden_image_2':
   data   => {
     name              => 'Golden_Image_2',
     description       => 'Golden image added from the file that is uploaded from a local drive',
-    golden_image_path => 'golden_image.zip'  # can be either an absolute or relative path
+    golden_image_path => 'golden_image.zip',  # can be either an absolute or relative path
+    timeout           => 3600
   }
 }
 

--- a/examples/image_streamer/golden_image.pp
+++ b/examples/image_streamer/golden_image.pp
@@ -33,7 +33,7 @@ image_streamer_golden_image{'golden_image_2':
     name              => 'Golden_Image_2',
     description       => 'Golden image added from the file that is uploaded from a local drive',
     golden_image_path => 'golden_image.zip',  # can be either an absolute or relative path
-    timeout           => 3600  # you can set a timeout (in seconds) for the upload
+    timeout           => 3600   # optionally sets a timeout (in seconds) for the upload
   }
 }
 

--- a/examples/image_streamer/golden_image.pp
+++ b/examples/image_streamer/golden_image.pp
@@ -33,7 +33,7 @@ image_streamer_golden_image{'golden_image_2':
     name              => 'Golden_Image_2',
     description       => 'Golden image added from the file that is uploaded from a local drive',
     golden_image_path => 'golden_image.zip',  # can be either an absolute or relative path
-    timeout           => 3600
+    timeout           => 3600  # you can set a timeout (in seconds) for the upload
   }
 }
 

--- a/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
@@ -29,10 +29,9 @@ Puppet::Type::Image_streamer_golden_image.provide :image_streamer, parent: Puppe
 
   def create
     current_resource = @resourcetype.find_by(@client, unique_id).first
-    return super unless @golden_image_path && !current_resource
     timeout = @data.delete('timeout') || OneviewSDK::Rest::READ_TIMEOUT
+    return super unless @golden_image_path && !current_resource
     @resourcetype.add(@client, @golden_image_path, @data, timeout)
-    true
   end
 
   def download_details_archive

--- a/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
@@ -30,7 +30,8 @@ Puppet::Type::Image_streamer_golden_image.provide :image_streamer, parent: Puppe
   def create
     current_resource = @resourcetype.find_by(@client, unique_id).first
     return super unless @golden_image_path && !current_resource
-    @resourcetype.add(@client, @golden_image_path, @data)
+    timeout = @data.delete('timeout') || OneviewSDK::Rest::READ_TIMEOUT
+    @resourcetype.add(@client, @golden_image_path, @data, timeout)
     true
   end
 

--- a/spec/unit/provider/image_streamer_golden_image_spec.rb
+++ b/spec/unit/provider/image_streamer_golden_image_spec.rb
@@ -96,14 +96,27 @@ describe provider_class, unit: true, if: api_version >= 300 do
       )
     end
 
+    let(:expected_data) do
+      { 'name' => resource['data']['name'],
+        'description' => resource['data']['description'] }
+    end
+
     before(:each) do
       allow(resourcetype).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
-    it 'should upload the file and add the golden image resource' do
+    it 'should upload the file and add the golden image resource with default timeout' do
       allow(resourcetype).to receive(:find_by).and_return([])
-      expect(resourcetype).to receive(:add).and_return(test)
+      timeout = OneviewSDK::Rest::READ_TIMEOUT
+      expect(resourcetype).to receive(:add).with(anything, '/path/to/upload/golden_image.zip', expected_data, timeout).and_return(test)
+      expect(provider.create).to be
+    end
+
+    it 'should upload the file and add the golden image resource with given timeout' do
+      resource['data']['timeout'] = 7_200
+      allow(resourcetype).to receive(:find_by).and_return([])
+      expect(resourcetype).to receive(:add).with(anything, '/path/to/upload/golden_image.zip', expected_data, 7_200).and_return(test)
       expect(provider.create).to be
     end
   end


### PR DESCRIPTION
### Description
Allows set a timeout for the Golden Image upload

### Issues Resolved
#133 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
