### PR TITLE
Add force option for download operations on Image_streamer_golden_image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#116](https://github.com/HewlettPackard/oneview-puppet/issues/116) Simplify login to i3s
 - [#121](https://github.com/HewlettPackard/oneview-puppet/issues/121) Deployment Plan and Golden Image should use the default uri parser
 - [#122](https://github.com/HewlettPackard/oneview-puppet/issues/122) Uri_parsing should support upper case for uri
+- [#132](https://github.com/HewlettPackard/oneview-puppet/issues/132) Allow option force for Image_streamer_golden_image download operations
 
 # 2.1.0 (2017-02-03)
 ### Version highlights:

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -585,12 +585,12 @@ This resource provides the following ensurable methods for managing Artifact Bun
 * `present` - Adds, uploads, or updates an artifact bundle resource based upon the attributes specified within `data`.
 * `found` - Searches for `image_streamer_artifact_bundle` resources on the appliance (with or without specific filters) and prints the name and uri of matches to the standard output.
 * `extract` - Extracts an artifact bundle and creates the artifacts on the appliance.
-* `download` - Downloads the content of an artifact bundle to a local drive.
+* `download` - Downloads the content of an artifact bundle to a local drive. You can set an option `force` within the `data` with value `true` to force the download even if the file already exists (default is false).
 * `get_backups` - Gets information about the backups.
 * `extract_backup` - Extracts the existing backup bundle on the appliance and creates all the artifacts. :exclamation: If there are any artifacts existing, they will be removed before the extract operation.
 * `create_backup` - Creates a backup bundle with all the artifacts present on the appliance. At any given point only one backup bundle will exist on the appliance.
 * `create_backup_from_file` - Uploads a backup bundle from a local drive and extracts all the artifacts present in the uploaded file. :exclamation: If there are any artifacts existing, they will be removed before the extract operation.
-* `download_backup` - Downloads a backup.
+* `download_backup` - Downloads a backup. You can set an option `force` within the `data` with value `true` to force the download even if the file already exists (default is false).
 * `absent` - Deletes an Artifact Bundle.
 
 Example file: [artifact_bundle.pp](examples/image_streamer/artifact_bundle.pp)
@@ -631,8 +631,8 @@ This resource provides the following ensurable methods for managing Golden Image
 
 * `present` - Adds or updates a golden resource based upon the attributes specified within `data`.
 * `found` - Searches for `image_streamer_golden_image` resources on the appliance (with or without specific filters) and prints the name and uri of matches to the standard output.
-* `download` - Downloads the content of a golden image.
-* `download_details_archive` - Downloads the details of the golden image capture logs which has been archived.
+* `download` - Downloads the content of a golden image. You can set an option `force` within the `data` with value `true` to force the download even if the file already exists (default is false).
+* `download_details_archive` - Downloads the details of the golden image capture logs which has been archived. You can set an option `force` within the `data` with value `true` to force the download even if the file already exists (default is false).
 * `absent` - Deletes a Golden Image.
 
 Example file: [golden_image.pp](examples/image_streamer/golden_image.pp)

--- a/examples/image_streamer/golden_image.pp
+++ b/examples/image_streamer/golden_image.pp
@@ -57,7 +57,8 @@ image_streamer_golden_image{'golden_image_5':
   require => Image_streamer_golden_image['golden_image_4'],
   data    => {
     name                 => 'Golden_Image_2',
-    details_archive_path => 'log_archive.zip'  # can be either an absolute or relative path
+    details_archive_path => 'log_archive.zip',  # can be either an absolute or relative path
+    force                => true
   }
 }
 
@@ -66,7 +67,8 @@ image_streamer_golden_image{'golden_image_6':
   require => Image_streamer_golden_image['golden_image_5'],
   data    => {
     name                       => 'Golden_Image_2',
-    golden_image_download_path => 'golden_image.zip',  # can be either an absolute or relative path
+    golden_image_download_path => 'golden_image_downloaded.zip',  # can be either an absolute or relative path
+    force                      => true
   }
 }
 

--- a/examples/image_streamer/golden_image.pp
+++ b/examples/image_streamer/golden_image.pp
@@ -58,7 +58,7 @@ image_streamer_golden_image{'golden_image_5':
   data    => {
     name                 => 'Golden_Image_2',
     details_archive_path => 'log_archive.zip',  # can be either an absolute or relative path
-    force                => true
+    force                => false  # does not overwrite the file when it already exists
   }
 }
 
@@ -68,7 +68,7 @@ image_streamer_golden_image{'golden_image_6':
   data    => {
     name                       => 'Golden_Image_2',
     golden_image_download_path => 'golden_image_downloaded.zip',  # can be either an absolute or relative path
-    force                      => true
+    force                      => false    # does not overwrite the file when it already exists
   }
 }
 

--- a/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
@@ -35,16 +35,20 @@ Puppet::Type::Image_streamer_golden_image.provide :image_streamer, parent: Puppe
   end
 
   def download_details_archive
-    archive_path = @data.delete('details_archive_path')
+    path = @data.delete('details_archive_path')
+    force = @data.delete('force')
     golden_image = get_single_resource_instance
-    golden_image.download_details_archive(archive_path)
+    raise "File #{path} already exists." if File.exist?(path) && !force
+    golden_image.download_details_archive(path)
     true
   end
 
   def download
-    download_path = @data.delete('golden_image_download_path')
+    path = @data.delete('golden_image_download_path')
+    force = @data.delete('force')
     golden_image = get_single_resource_instance
-    golden_image.download(download_path)
+    raise "File #{path} already exists." if File.exist?(path) && !force
+    golden_image.download(path)
     true
   end
 end

--- a/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
@@ -40,7 +40,6 @@ Puppet::Type::Image_streamer_golden_image.provide :image_streamer, parent: Puppe
     golden_image = get_single_resource_instance
     raise "File #{path} already exists." if File.exist?(path) && !force
     golden_image.download_details_archive(path)
-    true
   end
 
   def download
@@ -49,6 +48,5 @@ Puppet::Type::Image_streamer_golden_image.provide :image_streamer, parent: Puppe
     golden_image = get_single_resource_instance
     raise "File #{path} already exists." if File.exist?(path) && !force
     golden_image.download(path)
-    true
   end
 end

--- a/spec/unit/provider/image_streamer_golden_image_spec.rb
+++ b/spec/unit/provider/image_streamer_golden_image_spec.rb
@@ -109,14 +109,16 @@ describe provider_class, unit: true, if: api_version >= 300 do
   end
 
   context 'given the Archive Download parameters' do
+    let(:download_path) { '/path/to/download/details_archive.zip' }
+
     let(:resource) do
       Puppet::Type.type(:image_streamer_golden_image).new(
         name: 'golden-image-2',
         ensure: 'download_details_archive',
         data:
             {
-              'name'                     => 'Golden_Image_1',
-              'download_details_archive' => '/path/to/download/details_archive.zip'
+              'name'                 => 'Golden_Image_1',
+              'details_archive_path' => download_path
             }
       )
     end
@@ -126,13 +128,54 @@ describe provider_class, unit: true, if: api_version >= 300 do
       provider.exists?
     end
 
-    it 'should download the archived logs of the golden image' do
-      expect_any_instance_of(resourcetype).to receive(:download_details_archive)
-      expect(provider.download_details_archive).to be
+    context 'when file does not exist' do
+      before(:each) do
+        allow(File).to receive(:exist?).with(download_path).and_return(false)
+        expect_any_instance_of(resourcetype).to receive(:download_details_archive).with(download_path).and_return(true)
+      end
+
+      it 'should download the file' do
+        expect(provider.download_details_archive).to be
+      end
+
+      it 'should download if force is false' do
+        resource['data']['force'] = false
+        expect(provider.download_details_archive).to be
+      end
+
+      it 'should download if force is true' do
+        resource['data']['force'] = true
+        expect(provider.download_details_archive).to be
+      end
+    end
+
+    context 'when file already exists' do
+      before(:each) do
+        allow(File).to receive(:exist?).with(download_path).and_return(true)
+      end
+
+      it 'should raise error' do
+        expect_any_instance_of(resourcetype).not_to receive(:download_details_archive).and_return(true)
+        expect { provider.download_details_archive }.to raise_error('File /path/to/download/details_archive.zip already exists.')
+      end
+
+      it 'should raise error if force is false' do
+        resource['data']['force'] = false
+        expect_any_instance_of(resourcetype).not_to receive(:download_details_archive).and_return(true)
+        expect { provider.download_details_archive }.to raise_error('File /path/to/download/details_archive.zip already exists.')
+      end
+
+      it 'should download if force is true' do
+        resource['data']['force'] = true
+        expect_any_instance_of(resourcetype).to receive(:download_details_archive).with(download_path).and_return(true)
+        expect(provider.download_details_archive).to be
+      end
     end
   end
 
   context 'given the Download parameters' do
+    let(:download_path) { '/path/to/download/golden_image.zip' }
+
     let(:resource) do
       Puppet::Type.type(:image_streamer_golden_image).new(
         name: 'golden-image-2',
@@ -140,7 +183,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
         data:
             {
               'name'                       => 'Golden_Image_1',
-              'golden_image_download_path' => '/path/to/download/golden_image.zip'
+              'golden_image_download_path' => download_path
             }
       )
     end
@@ -150,9 +193,48 @@ describe provider_class, unit: true, if: api_version >= 300 do
       provider.exists?
     end
 
-    it 'should download the golden image' do
-      expect_any_instance_of(resourcetype).to receive(:download)
-      expect(provider.download).to be
+    context 'when file does not exist' do
+      before(:each) do
+        allow(File).to receive(:exist?).with(download_path).and_return(false)
+        expect_any_instance_of(resourcetype).to receive(:download).with(download_path).and_return(true)
+      end
+
+      it 'should download the file' do
+        expect(provider.download).to be
+      end
+
+      it 'should download if force is false' do
+        resource['data']['force'] = false
+        expect(provider.download).to be
+      end
+
+      it 'should download if force is true' do
+        resource['data']['force'] = true
+        expect(provider.download).to be
+      end
+    end
+
+    context 'when file already exists' do
+      before(:each) do
+        allow(File).to receive(:exist?).with(download_path).and_return(true)
+      end
+
+      it 'should raise error' do
+        expect_any_instance_of(resourcetype).not_to receive(:download).and_return(true)
+        expect { provider.download }.to raise_error('File /path/to/download/golden_image.zip already exists.')
+      end
+
+      it 'should raise error if force is false' do
+        resource['data']['force'] = false
+        expect_any_instance_of(resourcetype).not_to receive(:download).and_return(true)
+        expect { provider.download }.to raise_error('File /path/to/download/golden_image.zip already exists.')
+      end
+
+      it 'should download if force is true' do
+        resource['data']['force'] = true
+        expect_any_instance_of(resourcetype).to receive(:download).with(download_path).and_return(true)
+        expect(provider.download).to be
+      end
     end
   end
 end


### PR DESCRIPTION
### Description
Allows option **force** for the ensurables `download` and `download_details_archive`

### Issues Resolved
#132 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
