### PR TITLE
Refactor resource_update method and improve idempotency on update operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,15 @@
 - Image_streamer_plan_script
 
 #### Bug fixes & Enhancements:
+- [#95](https://github.com/HewlettPackard/oneview-puppet/issues/95) Improve server profile idempotency
 - [#103](https://github.com/HewlettPackard/oneview-puppet/issues/103) Unit tests should not require auth files/environment variables from the user
 - [#105](https://github.com/HewlettPackard/oneview-puppet/issues/105) Create or update uplink sets through logical interconnect groups
-- [#119](https://github.com/HewlettPackard/oneview-puppet/issues/119) Update unit tests to match updated remove_extra_unmanaged_volume from oneview-ruby-sdk
 - [#116](https://github.com/HewlettPackard/oneview-puppet/issues/116) Simplify login to i3s
+- [#119](https://github.com/HewlettPackard/oneview-puppet/issues/119) Update unit tests to match updated remove_extra_unmanaged_volume from oneview-ruby-sdk
 - [#121](https://github.com/HewlettPackard/oneview-puppet/issues/121) Deployment Plan and Golden Image should use the default uri parser
 - [#122](https://github.com/HewlettPackard/oneview-puppet/issues/122) Uri_parsing should support upper case for uri
-- [#133](https://github.com/HewlettPackard/oneview-puppet/issues/133) Allow set a timeout for Image_streamer_golden_image upload
 - [#132](https://github.com/HewlettPackard/oneview-puppet/issues/132) Allow option force for Image_streamer_golden_image download operations
+- [#133](https://github.com/HewlettPackard/oneview-puppet/issues/133) Allow set a timeout for Image_streamer_golden_image upload
 
 # 2.1.0 (2017-02-03)
 ### Version highlights:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 #### Bug fixes & Enhancements:
 - [#95](https://github.com/HewlettPackard/oneview-puppet/issues/95) Improve server profile idempotency
+- [#101](https://github.com/HewlettPackard/oneview-puppet/issues/101) Improve server profile template idempotency 
 - [#103](https://github.com/HewlettPackard/oneview-puppet/issues/103) Unit tests should not require auth files/environment variables from the user
 - [#105](https://github.com/HewlettPackard/oneview-puppet/issues/105) Create or update uplink sets through logical interconnect groups
 - [#116](https://github.com/HewlettPackard/oneview-puppet/issues/116) Simplify login to i3s

--- a/examples/logical_interconnect_group.pp
+++ b/examples/logical_interconnect_group.pp
@@ -155,59 +155,45 @@ oneview_logical_interconnect_group{'Puppet LIG C7000 Full':
     'interconnectMapTemplate' => {
       'interconnectMapEntryTemplates' => [
         {
-          'logicalLocation'                => {
+          'logicalLocation'              => {
             'locationEntries' => [
               {
-                'relativeValue'   => 1,
-                'type'            => 'Bay'
+                'relativeValue' => 1,
+                'type'          => 'Bay'
               },
               {
-                'relativeValue'   => 1,
-                'type'            => 'Enclosure'
+                'relativeValue' => 1,
+                'type'          => 'Enclosure'
               }
             ]
           },
-          'permittedInterconnectTypeUri'   => '/rest/interconnect-types/005ef42f-eb2e-44ff-bc6d-d736d1705f72'
+          'permittedInterconnectTypeUri' => '/rest/interconnect-types/005ef42f-eb2e-44ff-bc6d-d736d1705f72'
         },
         {
-          'logicalLocation'                => {
+          'logicalLocation'              => {
             'locationEntries' => [
               {
-                'relativeValue'   => 2,
-                'type'            => 'Bay'
+                'relativeValue' => 2,
+                'type'          => 'Bay'
               },
               {
-                'relativeValue'   => 1,
-                'type'            => 'Enclosure'
+                'relativeValue' => 1,
+                'type'          => 'Enclosure'
               }
             ]
           },
-          'permittedInterconnectTypeUri'   => '/rest/interconnect-types/005ef42f-eb2e-44ff-bc6d-d736d1705f72'
-        },
-        {
-          'logicalLocation' => {
-            'locationEntries' => [
-              {
-                'relativeValue'   => 3,
-                'type'            => 'Bay'
-              },
-              {
-                'relativeValue'   => 1,
-                'type'            => 'Enclosure'
-              }
-            ]
-          },
+          'permittedInterconnectTypeUri' => '/rest/interconnect-types/005ef42f-eb2e-44ff-bc6d-d736d1705f72'
         },
         {
           'logicalLocation' => {
             'locationEntries' => [
               {
-                'relativeValue'   => 4,
-                'type'            => 'Bay'
+                'relativeValue' => 3,
+                'type'          => 'Bay'
               },
               {
-                'relativeValue'   => 1,
-                'type'            => 'Enclosure'
+                'relativeValue' => 1,
+                'type'          => 'Enclosure'
               }
             ]
           },
@@ -216,12 +202,12 @@ oneview_logical_interconnect_group{'Puppet LIG C7000 Full':
           'logicalLocation' => {
             'locationEntries' => [
               {
-                'relativeValue'   => 5,
-                'type'            => 'Bay'
+                'relativeValue' => 4,
+                'type'          => 'Bay'
               },
               {
-                'relativeValue'   => 1,
-                'type'            => 'Enclosure'
+                'relativeValue' => 1,
+                'type'          => 'Enclosure'
               }
             ]
           },
@@ -230,12 +216,12 @@ oneview_logical_interconnect_group{'Puppet LIG C7000 Full':
           'logicalLocation' => {
             'locationEntries' => [
               {
-                'relativeValue'   => 6,
-                'type'            => 'Bay'
+                'relativeValue' => 5,
+                'type'          => 'Bay'
               },
               {
-                'relativeValue'   => 1,
-                'type'            => 'Enclosure'
+                'relativeValue' => 1,
+                'type'          => 'Enclosure'
               }
             ]
           },
@@ -244,12 +230,12 @@ oneview_logical_interconnect_group{'Puppet LIG C7000 Full':
           'logicalLocation' => {
             'locationEntries' => [
               {
-                'relativeValue'   => 7,
-                'type'            => 'Bay'
+                'relativeValue' => 6,
+                'type'          => 'Bay'
               },
               {
-                'relativeValue'   => 1,
-                'type'            => 'Enclosure'
+                'relativeValue' => 1,
+                'type'          => 'Enclosure'
               }
             ]
           },
@@ -258,12 +244,26 @@ oneview_logical_interconnect_group{'Puppet LIG C7000 Full':
           'logicalLocation' => {
             'locationEntries' => [
               {
-                'relativeValue'   => 8,
-                'type'            => 'Bay'
+                'relativeValue' => 7,
+                'type'          => 'Bay'
               },
               {
-                'relativeValue'   => 1,
-                'type'            => 'Enclosure'
+                'relativeValue' => 1,
+                'type'          => 'Enclosure'
+              }
+            ]
+          },
+        },
+        {
+          'logicalLocation' => {
+            'locationEntries' => [
+              {
+                'relativeValue' => 8,
+                'type'          => 'Bay'
+              },
+              {
+                'relativeValue' => 1,
+                'type'          => 'Enclosure'
               }
             ]
           },

--- a/lib/puppet/provider/common.rb
+++ b/lib/puppet/provider/common.rb
@@ -40,13 +40,13 @@ end
 # Updates resource if it exists and is different from the expected.
 # Returns false if resource does not exist and true if it exists or if it was updated.
 def resource_update
-  current_resource = @resourcetype.new(@client, @data)
+  current_resource = @resource_type.new(@client, @data)
   return false unless current_resource.retrieve!
   parse_new_name
   if current_resource.like?(@data)
-    Puppet.notice "#{@resourcetype} #{@data['name']} is up to date."
+    Puppet.notice "#{@resource_type} #{@data['name']} is up to date."
   else
-    Puppet.notice "#{@resourcetype} #{@data['name']} differs from resource in appliance."
+    Puppet.notice "#{@resource_type} #{@data['name']} differs from resource in appliance."
     Puppet.debug "Current attributes: #{JSON.pretty_generate(current_resource.data)}"
     Puppet.debug "Desired attributes: #{JSON.pretty_generate(@data)}"
     current_resource.update(@data)
@@ -58,14 +58,14 @@ end
 # Validation for name change on resource through flag 'new_name'
 def parse_new_name
   return unless @data['new_name']
-  raise 'new_name field contains an existing resource name.' if @resourcetype.new(@client, name: @data['new_name']).retrieve!
+  raise 'new_name field contains an existing resource name.' if @resource_type.new(@client, name: @data['new_name']).retrieve!
   @data['name'] = @data.delete('new_name')
 end
 
 def get_single_resource_instance
   # Expects to find exactly 1 resources with the data provided, otherwise fails
   # This should NOT be used for deletes/destroys as it can be used without a unique identifier in a context where only one resouce exists.
-  found_resource = @resourcetype.find_by(@client, @data)
+  found_resource = @resource_type.find_by(@client, @data)
   raise 'More than one resource matched the data specified. Specify a unique identifier on data.' if found_resource.size > 1
   raise 'No resources with the specified data specified were found. Specify a valid unique identifier on data.' if found_resource.empty?
   found_resource.first
@@ -79,8 +79,8 @@ end
 
 def find_resources
   # Searches ServerHardware with data matching the manifest data
-  retrieved_resources = @resourcetype.find_by(@client, @data)
-  resource_name = @resourcetype.to_s.split('::').last
+  retrieved_resources = @resource_type.find_by(@client, @data)
+  resource_name = @resource_type.to_s.split('::').last
   # If resources are found, iterate through them and notify. Else just notify.
   raise "\n\nNo #{resource_name} with the specified data were found on the Oneview Appliance\n" if retrieved_resources.empty?
   retrieved_resources.each do |retrieved_resource|

--- a/lib/puppet/provider/common.rb
+++ b/lib/puppet/provider/common.rb
@@ -40,26 +40,27 @@ end
 # Updates resource if it exists and is different from the expected.
 # Returns false if resource does not exist and true if it exists or if it was updated.
 def resource_update
-  current_resource = @resource_type.new(@client, @data)
-  return false unless current_resource.retrieve!
+  @new_name = @data.delete('new_name')
+  @item = @resource_type.new(@client, @data)
+  return false unless @item.retrieve!
   parse_new_name
-  if current_resource.like?(@data)
+  if @item.like?(@data)
     Puppet.notice "#{@resource_type} #{@data['name']} is up to date."
   else
     Puppet.notice "#{@resource_type} #{@data['name']} differs from resource in appliance."
-    Puppet.debug "Current attributes: #{JSON.pretty_generate(current_resource.data)}"
+    Puppet.debug "Current attributes: #{JSON.pretty_generate(@item.data)}"
     Puppet.debug "Desired attributes: #{JSON.pretty_generate(@data)}"
-    current_resource.update(@data)
-    @property_hash[:data] = current_resource.data
+    @item.update(@data)
+    @property_hash[:data] = @item.data
   end
   true
 end
 
 # Validation for name change on resource through flag 'new_name'
 def parse_new_name
-  return unless @data['new_name']
-  raise 'new_name field contains an existing resource name.' if @resource_type.new(@client, name: @data['new_name']).retrieve!
-  @data['name'] = @data.delete('new_name')
+  return unless @new_name
+  raise 'new_name field contains an existing resource name.' if @resource_type.new(@client, name: @new_name).retrieve!
+  @data['name'] = @new_name
 end
 
 def get_single_resource_instance

--- a/lib/puppet/provider/common.rb
+++ b/lib/puppet/provider/common.rb
@@ -37,23 +37,29 @@ def data_parse(data = {})
   data
 end
 
-def resource_update(data, resourcetype)
-  current_resource = resourcetype.find_by(@client, unique_id).first
-  return false unless current_resource
-  current_attributes = current_resource.data
-  new_name_validation(data, resourcetype)
-  raw_merged_data = current_attributes.merge(data)
-  updated_data = Hash[raw_merged_data.to_a - current_attributes.to_a]
-  current_resource.update(updated_data) unless updated_data.empty?
-  @property_hash[:data] = current_resource.data
+# Updates resource if it exists and is different from the expected.
+# Returns false if resource does not exist and true if it exists or if it was updated.
+def resource_update
+  current_resource = @resourcetype.new(@client, @data)
+  return false unless current_resource.retrieve!
+  parse_new_name
+  if current_resource.like?(@data)
+    Puppet.notice "#{@resourcetype} #{@data['name']} is up to date."
+  else
+    Puppet.notice "#{@resourcetype} #{@data['name']} differs from resource in appliance."
+    Puppet.debug "Current attributes: #{JSON.pretty_generate(current_resource.data)}"
+    Puppet.debug "Desired attributes: #{JSON.pretty_generate(@data)}"
+    current_resource.update(@data)
+    @property_hash[:data] = current_resource.data
+  end
   true
 end
 
-def new_name_validation(data, resourcetype)
-  # Validation for name change on resource through flag 'new_name'
-  return unless data['new_name']
-  new_resource_name_used = resourcetype.find_by(@client, name: data['new_name']).first
-  data['name'] = data.delete('new_name') unless new_resource_name_used
+# Validation for name change on resource through flag 'new_name'
+def parse_new_name
+  return unless @data['new_name']
+  raise 'new_name field contains an existing resource name.' if @resourcetype.new(@client, name: @data['new_name']).retrieve!
+  @data['name'] = @data.delete('new_name')
 end
 
 def get_single_resource_instance

--- a/lib/puppet/provider/image_streamer_artifact_bundle/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_artifact_bundle/image_streamer.rb
@@ -31,15 +31,15 @@ Puppet::Type.type(:image_streamer_artifact_bundle).provide :image_streamer, pare
   end
 
   def create
-    current_resource = @resourcetype.find_by(@client, unique_id).first
+    current_resource = @resource_type.find_by(@client, unique_id).first
     if current_resource
       return true unless @data['new_name']
       current_resource.update_name(@data['new_name'])
     elsif @data['artifact_bundle_path']
       @data['timeout'] ||= OneviewSDK::Rest::READ_TIMEOUT
-      @resourcetype.create_from_file(@client, @data['artifact_bundle_path'], @data['name'], @data['timeout']).data
+      @resource_type.create_from_file(@client, @data['artifact_bundle_path'], @data['name'], @data['timeout']).data
     else
-      @resourcetype.new(@client, @data).create.data
+      @resource_type.new(@client, @data).create.data
     end
   end
 
@@ -57,31 +57,31 @@ Puppet::Type.type(:image_streamer_artifact_bundle).provide :image_streamer, pare
   end
 
   def get_backups
-    backups = @resourcetype.get_backups(@client)
+    backups = @resource_type.get_backups(@client)
     backups.each { |item| pretty item.data }
     true
   end
 
   def extract_backup
-    @resourcetype.extract_backup(@client, get_deployment_group, 'uri' => '/archive')
+    @resource_type.extract_backup(@client, get_deployment_group, 'uri' => '/archive')
   end
 
   def create_backup
-    @resourcetype.create_backup(@client, get_deployment_group)
+    @resource_type.create_backup(@client, get_deployment_group)
   end
 
   def create_backup_from_file
     path = @data.delete('backup_upload_path')
     @data['timeout'] ||= OneviewSDK::Rest::READ_TIMEOUT
-    @resourcetype.create_backup_from_file!(@client, get_deployment_group, path, File.basename(path), @data['timeout'])
+    @resource_type.create_backup_from_file!(@client, get_deployment_group, path, File.basename(path), @data['timeout'])
   end
 
   def download_backup
     path = @data.delete('backup_download_path')
     force = @data.delete('force')
     raise "File #{path} already exists." if File.exist?(path) && !force
-    backup = @resourcetype.get_backups(@client)
-    @resourcetype.download_backup(@client, path, backup.first)
+    backup = @resource_type.get_backups(@client)
+    @resource_type.download_backup(@client, path, backup.first)
   end
 
   def get_deployment_group

--- a/lib/puppet/provider/image_streamer_deployment_plan/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_deployment_plan/image_streamer.rb
@@ -23,6 +23,6 @@ Puppet::Type.type(:image_streamer_deployment_plan).provide :image_streamer, pare
 
   def exists?
     super
-    @resourcetype.find_by(@client, @data).any?
+    @resource_type.find_by(@client, @data).any?
   end
 end

--- a/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
@@ -24,14 +24,14 @@ Puppet::Type::Image_streamer_golden_image.provide :image_streamer, parent: Puppe
   def exists?
     super([nil, :found, :download_details_archive, :download])
     @golden_image_path = @data.delete('golden_image_path')
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def create
-    current_resource = @resourcetype.find_by(@client, unique_id).first
+    current_resource = @resource_type.find_by(@client, unique_id).first
     timeout = @data.delete('timeout') || OneviewSDK::Rest::READ_TIMEOUT
     return super unless @golden_image_path && !current_resource
-    @resourcetype.add(@client, @golden_image_path, @data, timeout)
+    @resource_type.add(@client, @golden_image_path, @data, timeout)
   end
 
   def download_details_archive

--- a/lib/puppet/provider/oneview_connection_template/c7000.rb
+++ b/lib/puppet/provider/oneview_connection_template/c7000.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:oneview_connection_template).provide :c7000, parent: Puppet::
     @data = data_parse
     empty_data_check([nil, :found, :get_default_connection_template])
     ct = if resource['ensure'] == :present
-           resource_update(@data, @resourcetype)
+           resource_update
            @resourcetype.find_by(@client, unique_id)
          else
            @resourcetype.find_by(@client, @data)

--- a/lib/puppet/provider/oneview_connection_template/c7000.rb
+++ b/lib/puppet/provider/oneview_connection_template/c7000.rb
@@ -28,9 +28,9 @@ Puppet::Type.type(:oneview_connection_template).provide :c7000, parent: Puppet::
     empty_data_check([nil, :found, :get_default_connection_template])
     ct = if resource['ensure'] == :present
            resource_update
-           @resourcetype.find_by(@client, unique_id)
+           @resource_type.find_by(@client, unique_id)
          else
-           @resourcetype.find_by(@client, @data)
+           @resource_type.find_by(@client, @data)
          end
     !ct.empty?
   end
@@ -45,7 +45,7 @@ Puppet::Type.type(:oneview_connection_template).provide :c7000, parent: Puppet::
 
   def get_default_connection_template
     Puppet.notice("\n\nDefault Connection Template")
-    default = @resourcetype.get_default(@client)
+    default = @resource_type.get_default(@client)
     if default['uri']
       puts "\nName: '#{default['name']}'"
       puts "(- maximumBandwidth: #{default['bandwidth']['maximumBandwidth']})"

--- a/lib/puppet/provider/oneview_datacenter/c7000.rb
+++ b/lib/puppet/provider/oneview_datacenter/c7000.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:oneview_datacenter).provide :c7000, parent: Puppet::OneviewRe
   end
 
   def destroy
-    datacenter = @resourcetype.find_by(@client, @data)
+    datacenter = @resource_type.find_by(@client, @data)
     raise('There were no matching Datacenters in the Appliance.') if datacenter.empty?
     datacenter.map(&:remove)
   end

--- a/lib/puppet/provider/oneview_drive_enclosure/synergy.rb
+++ b/lib/puppet/provider/oneview_drive_enclosure/synergy.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:oneview_drive_enclosure).provide :synergy, parent: Puppet::On
     super
     return true if @data.empty?
     perform_patch
-    @resourcetype.new(@client, @data).exists?
+    @resource_type.new(@client, @data).exists?
   end
 
   def create

--- a/lib/puppet/provider/oneview_enclosure/c7000.rb
+++ b/lib/puppet/provider/oneview_enclosure/c7000.rb
@@ -35,14 +35,14 @@ Puppet::Type.type(:oneview_enclosure).provide :c7000, parent: Puppet::OneviewRes
     empty_data_check
     %w(from op path value).each { |key| @patch_tags[key] = @data.delete(key) if @data[key] }
     %w(hostname username password).each { |key| @authentication[key] = @data.delete(key) if @data[key] }
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def create
     patch_enclosure unless @patch_tags.empty?
     return true if resource_update
     @data = @data.merge(@authentication)
-    @resourcetype.new(@client, @data).add
+    @resource_type.new(@client, @data).add
     @property_hash[:ensure] = :present
     @property_hash[:data] = @data
     true

--- a/lib/puppet/provider/oneview_enclosure/c7000.rb
+++ b/lib/puppet/provider/oneview_enclosure/c7000.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:oneview_enclosure).provide :c7000, parent: Puppet::OneviewRes
 
   def create
     patch_enclosure unless @patch_tags.empty?
-    return true if resource_update(@data, @resourcetype)
+    return true if resource_update
     @data = @data.merge(@authentication)
     @resourcetype.new(@client, @data).add
     @property_hash[:ensure] = :present

--- a/lib/puppet/provider/oneview_enclosure_group/c7000.rb
+++ b/lib/puppet/provider/oneview_enclosure_group/c7000.rb
@@ -29,7 +29,7 @@ Puppet::Type.type(:oneview_enclosure_group).provide :c7000, parent: Puppet::Onev
   end
 
   def create
-    return true if resource_update(@data, @resourcetype)
+    return true if resource_update
     @resourcetype.new(@client, enclosure_group_parse(@data)).create
   end
 

--- a/lib/puppet/provider/oneview_enclosure_group/c7000.rb
+++ b/lib/puppet/provider/oneview_enclosure_group/c7000.rb
@@ -25,12 +25,12 @@ Puppet::Type.type(:oneview_enclosure_group).provide :c7000, parent: Puppet::Onev
   def exists?
     @data = enclosure_group_parse(data_parse)
     empty_data_check
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def create
     return true if resource_update
-    @resourcetype.new(@client, enclosure_group_parse(@data)).create
+    @resource_type.new(@client, enclosure_group_parse(@data)).create
   end
 
   def get_script

--- a/lib/puppet/provider/oneview_ethernet_network/c7000.rb
+++ b/lib/puppet/provider/oneview_ethernet_network/c7000.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:oneview_ethernet_network).provide :c7000, parent: Puppet::One
   def exists?
     super
     @bandwidth = @data.delete('bandwidth') unless @data['vlanIdRange']
-    @resourcetype.find_by(@client, @data).any?
+    @resource_type.find_by(@client, @data).any?
   end
 
   def create
@@ -34,7 +34,7 @@ Puppet::Type.type(:oneview_ethernet_network).provide :c7000, parent: Puppet::One
     update_connection_template if @bandwidth
     # Checks if the operation is an update, bulk create or neither
     return true if bulk_create_check || resource_update
-    @resourcetype.new(@client, @data).create
+    @resource_type.new(@client, @data).create
   end
 
   def get_associated_profiles
@@ -72,7 +72,7 @@ Puppet::Type.type(:oneview_ethernet_network).provide :c7000, parent: Puppet::One
     if @data['vlanIdRange']
       Puppet.warning 'Deprecation warning! Bulk creation cannot be correctly maintained with idempotency,
        so it will be discontinued in future releases. Adopt the single resource style creation in the future.'
-      @resourcetype.bulk_create(@client, bulk_parse(@data))
+      @resource_type.bulk_create(@client, bulk_parse(@data))
     else
       false
     end
@@ -87,7 +87,7 @@ Puppet::Type.type(:oneview_ethernet_network).provide :c7000, parent: Puppet::One
   # Checks whether the connection template needs to be updated
   def update_connection_template
     # Get single resource instance cannot be used because its @data may contain new_name
-    network = @resourcetype.find_by(@client, unique_id).first
+    network = @resource_type.find_by(@client, unique_id).first
     @bandwidth.each { |key, value| @bandwidth[key] = value.to_i }
     connection_template = OneviewSDK::ConnectionTemplate.find_by(@client, uri: network['connectionTemplateUri']).first
     connection_template_current_bandwidth = connection_template['bandwidth']

--- a/lib/puppet/provider/oneview_ethernet_network/c7000.rb
+++ b/lib/puppet/provider/oneview_ethernet_network/c7000.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:oneview_ethernet_network).provide :c7000, parent: Puppet::One
     # Checks if there is a connection template update
     update_connection_template if @bandwidth
     # Checks if the operation is an update, bulk create or neither
-    return true if bulk_create_check || resource_update(@data, @resourcetype)
+    return true if bulk_create_check || resource_update
     @resourcetype.new(@client, @data).create
   end
 

--- a/lib/puppet/provider/oneview_fabric/synergy.rb
+++ b/lib/puppet/provider/oneview_fabric/synergy.rb
@@ -25,6 +25,6 @@ Puppet::Type.type(:oneview_fabric).provide :synergy, parent: :c7000 do
   end
 
   def set_reserved_vlan_range
-    @resourcetype.find_by(@client, unique_id).first.set_reserved_vlan_range(@data['fabric_options'])
+    @resource_type.find_by(@client, unique_id).first.set_reserved_vlan_range(@data['fabric_options'])
   end
 end

--- a/lib/puppet/provider/oneview_firmware_bundle/c7000.rb
+++ b/lib/puppet/provider/oneview_firmware_bundle/c7000.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:oneview_firmware_bundle).provide :c7000, parent: Puppet::Onev
   end
 
   def create
-    @resourcetype.add(@client, @data['firmware_bundle_path'], @data['timeout'])
+    @resource_type.add(@client, @data['firmware_bundle_path'], @data['timeout'])
   end
 
   def destroy

--- a/lib/puppet/provider/oneview_firmware_driver/c7000.rb
+++ b/lib/puppet/provider/oneview_firmware_driver/c7000.rb
@@ -32,13 +32,13 @@ Puppet::Type.type(:oneview_firmware_driver).provide :c7000, parent: Puppet::Onev
   def exists?
     @data = data_parse
     data_parse_for_general
-    @resourcetype.find_by(@client, @data).any?
+    @resource_type.find_by(@client, @data).any?
   end
 
   def create
     @data = @data.merge(@attributes)
     @data['customBaselineName'] = @data.delete('name') if @data['name']
-    @resourcetype.new(@client, @data).create
+    @resource_type.new(@client, @data).create
     @property_hash[:ensure] = :present
     @property_hash[:data] = @data
     true
@@ -70,7 +70,7 @@ Puppet::Type.type(:oneview_firmware_driver).provide :c7000, parent: Puppet::Onev
       end
     end
     return if value.to_s[0..6].include?('/rest/')
-    firmware_driver = @resourcetype.find_by(@client, name: value)
+    firmware_driver = @resource_type.find_by(@client, name: value)
     raise "No #{key}s found on the appliance matching the provided name #{value}. Provide a valid name or uri." if firmware_driver.empty?
     if extra
       @attributes[key][extra] = firmware_driver.first['uri']

--- a/lib/puppet/provider/oneview_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_interconnect/c7000.rb
@@ -29,7 +29,7 @@ Puppet::Type.type(:oneview_interconnect).provide :c7000, parent: Puppet::Oneview
     variable_assignments
     # Checks if there is a patch update to be performed
     get_single_resource_instance.patch(@patch['op'], @patch['path'], @patch['value']) if @patch
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def create
@@ -43,9 +43,9 @@ Puppet::Type.type(:oneview_interconnect).provide :c7000, parent: Puppet::Oneview
   def get_types
     Puppet.notice("\n\nInterconnect Types\n")
     if @data['name']
-      pretty @resourcetype.get_type(@client, @data['name'])
+      pretty @resource_type.get_type(@client, @data['name'])
     else
-      pretty @resourcetype.get_types(@client)
+      pretty @resource_type.get_types(@client)
     end
     true
   end

--- a/lib/puppet/provider/oneview_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_interconnect/synergy.rb
@@ -23,9 +23,9 @@ Puppet::Type.type(:oneview_interconnect).provide :synergy, parent: :c7000 do
   def get_link_topologies
     Puppet.notice("\n\nInterconnect link topologies:\n")
     if @data['name']
-      pretty @resourcetype.get_link_topology(@client, @data['name'])
+      pretty @resource_type.get_link_topology(@client, @data['name'])
     else
-      pretty @resourcetype.get_link_topologies(@client)
+      pretty @resource_type.get_link_topologies(@client)
     end
     true
   end

--- a/lib/puppet/provider/oneview_logical_downlink/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_downlink/c7000.rb
@@ -38,7 +38,7 @@ Puppet::Type.type(:oneview_logical_downlink).provide :c7000, parent: Puppet::One
   def get_without_ethernet
     Puppet.notice("\n\nLogical Downlink Without Ethernet\n")
     if @data.empty?
-      list = @resourcetype.get_without_ethernet(@client)
+      list = @resource_type.get_without_ethernet(@client)
       raise('There is no Logical Downlink without ethernet in the Oneview appliance.') if list.empty?
       list.each { |item| pretty item.data }
     else

--- a/lib/puppet/provider/oneview_logical_enclosure/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_enclosure/c7000.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:oneview_logical_enclosure).provide :c7000, parent: Puppet::On
     super
     @patch = @data.delete('patch')
     get_single_resource_instance.patch(@patch['op'], @patch['path'], @patch['value']) if @patch
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def get_script

--- a/lib/puppet/provider/oneview_logical_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect/c7000.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:oneview_logical_interconnect).provide :c7000, parent: Puppet:
     empty_data_check
     variable_assignments
     li = if resource['ensure'] == :present
-           resource_update(@data, @resourcetype)
+           resource_update
            @resourcetype.find_by(@client, unique_id)
          else
            @resourcetype.find_by(@client, @data)

--- a/lib/puppet/provider/oneview_logical_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect/c7000.rb
@@ -29,9 +29,9 @@ Puppet::Type.type(:oneview_logical_interconnect).provide :c7000, parent: Puppet:
     variable_assignments
     li = if resource['ensure'] == :present
            resource_update
-           @resourcetype.find_by(@client, unique_id)
+           @resource_type.find_by(@client, unique_id)
          else
-           @resourcetype.find_by(@client, @data)
+           @resource_type.find_by(@client, @data)
          end
     !li.empty?
   end

--- a/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
@@ -39,12 +39,12 @@ Puppet::Type.type(:oneview_logical_interconnect_group).provide :c7000, parent: P
     @data['uplinkSets'] = parse_uplink_sets if @uplink_sets
     @data['interconnectMapTemplate'] = parse_interconnects if @interconnects
     @data['internalNetworkUris'] = parse_internal_networks if @internal_network_uris
-    @resourcetype.find_by(@client, @data).any?
+    @resource_type.find_by(@client, @data).any?
   end
 
   def create
     new_name = @data.delete('new_name')
-    lig = @resourcetype.new(@client, @data)
+    lig = @resource_type.new(@client, @data)
     @data['new_name'] = new_name if new_name
     return true if resource_update
     lig.create
@@ -60,7 +60,7 @@ Puppet::Type.type(:oneview_logical_interconnect_group).provide :c7000, parent: P
 
   def get_default_settings
     Puppet.notice("\n\nLogical Interconnect Group Default Settings\n")
-    pretty @resourcetype.get_default_settings(@client)
+    pretty @resource_type.get_default_settings(@client)
     true
   end
 

--- a/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:oneview_logical_interconnect_group).provide :c7000, parent: P
     new_name = @data.delete('new_name')
     lig = @resourcetype.new(@client, @data)
     @data['new_name'] = new_name if new_name
-    return true if resource_update(@data, @resourcetype)
+    return true if resource_update
     lig.create
     @property_hash[:data] = lig.data
     @property_hash[:ensure] = :present

--- a/lib/puppet/provider/oneview_logical_interconnect_group/synergy.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/synergy.rb
@@ -29,7 +29,7 @@ Puppet::Type.type(:oneview_logical_interconnect_group).provide :synergy, parent:
 
   def get_default_settings
     Puppet.notice("\n\nLogical Interconnect Group Default Settings\n")
-    pretty @resourcetype.get_default_settings
+    pretty @resource_type.get_default_settings
     true
   end
 end

--- a/lib/puppet/provider/oneview_logical_switch/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_switch/c7000.rb
@@ -36,7 +36,7 @@ Puppet::Type.type(:oneview_logical_switch).provide :c7000, parent: Puppet::Onevi
 
   def create
     return true if resource_update
-    ls = @resourcetype.new(@client, @data)
+    ls = @resource_type.new(@client, @data)
     set_switches(ls, @switches)
     ls.create
     @property_hash[:data] = ls.data

--- a/lib/puppet/provider/oneview_logical_switch/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_switch/c7000.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:oneview_logical_switch).provide :c7000, parent: Puppet::Onevi
   end
 
   def create
-    return true if resource_update(@data, @resourcetype)
+    return true if resource_update
     ls = @resourcetype.new(@client, @data)
     set_switches(ls, @switches)
     ls.create

--- a/lib/puppet/provider/oneview_logical_switch_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_switch_group/c7000.rb
@@ -28,12 +28,12 @@ Puppet::Type.type(:oneview_logical_switch_group).provide :c7000, parent: Puppet:
     empty_data_check
     switch_type_uri if @data['switchMapTemplate']
     @switches = @data.delete('switches')
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def create
     new_name = @data.delete('new_name')
-    lsg = @resourcetype.new(@client, @data)
+    lsg = @resource_type.new(@client, @data)
     lsg.set_grouping_parameters(@switches['number_of_switches'].to_i, @switches['type'].to_s) if @switches
     @data['new_name'] = new_name if new_name
     return true if resource_update

--- a/lib/puppet/provider/oneview_logical_switch_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_switch_group/c7000.rb
@@ -36,7 +36,7 @@ Puppet::Type.type(:oneview_logical_switch_group).provide :c7000, parent: Puppet:
     lsg = @resourcetype.new(@client, @data)
     lsg.set_grouping_parameters(@switches['number_of_switches'].to_i, @switches['type'].to_s) if @switches
     @data['new_name'] = new_name if new_name
-    return true if resource_update(@data, @resourcetype)
+    return true if resource_update
     lsg.create
   end
 end

--- a/lib/puppet/provider/oneview_network_set/c7000.rb
+++ b/lib/puppet/provider/oneview_network_set/c7000.rb
@@ -32,13 +32,13 @@ Puppet::Type.type(:oneview_network_set).provide :c7000, parent: Puppet::OneviewR
     @data = data_parse
     network_uris
     empty_data_check([:found, :get_without_ethernet])
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def get_without_ethernet
     Puppet.notice("\n\nNetwork Set Without Ethernet\n")
     if @data.empty?
-      list = @resourcetype.get_without_ethernet(@client)
+      list = @resource_type.get_without_ethernet(@client)
       raise('There is no Network Set without ethernet in the Oneview appliance.') if list.empty?
       list.each { |item| pretty item }
     else

--- a/lib/puppet/provider/oneview_power_device/c7000.rb
+++ b/lib/puppet/provider/oneview_power_device/c7000.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:oneview_power_device).provide :c7000, parent: Puppet::Oneview
     empty_data_check([:found, :absent])
     pd_uri_parser
     variable_assignments
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def create
@@ -37,13 +37,13 @@ Puppet::Type.type(:oneview_power_device).provide :c7000, parent: Puppet::Oneview
 
   # Remove
   def destroy
-    pd = @resourcetype.find_by(@client, @data)
+    pd = @resource_type.find_by(@client, @data)
     raise('There were no matching Power Devices in the Appliance.') if pd.empty?
     pd.map(&:remove)
   end
 
   def discover
-    pd = @resourcetype.discover(@client, @data)
+    pd = @resource_type.discover(@client, @data)
     Puppet.notice("IPDU #{pd['name']} has been discovered!")
   end
 

--- a/lib/puppet/provider/oneview_rack/c7000.rb
+++ b/lib/puppet/provider/oneview_rack/c7000.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:oneview_rack).provide :c7000, parent: Puppet::OneviewResource
   end
 
   def destroy
-    racks = @resourcetype.find_by(@client, @data)
+    racks = @resource_type.find_by(@client, @data)
     raise 'No racks matching the specified data were found' if racks.empty?
     racks.each do |rack|
       Puppet.notice "\n\n Removing rack named: #{rack['name']}, with uri: #{rack['uri']}\n"

--- a/lib/puppet/provider/oneview_resource.rb
+++ b/lib/puppet/provider/oneview_resource.rb
@@ -82,7 +82,7 @@ module Puppet
 
     # TODO: Would be awesome to have this working for everything/most types. Future improvement. Leaving as is in the meanwhile for filler.
     def create(action = :create)
-      return true if resource_update(@data, @resourcetype)
+      return true if resource_update
       ov_resource = if action == :create
                       @resourcetype.new(@client, @data).create
                     elsif action == :add

--- a/lib/puppet/provider/oneview_resource.rb
+++ b/lib/puppet/provider/oneview_resource.rb
@@ -28,7 +28,7 @@ module Puppet
       @property_flush ||= {}
       @data ||= {}
       @client ||= client
-      @resourcetype ||= ov_resource_type
+      @resource_type ||= ov_resource_type
     end
 
     def self.oneview_class
@@ -76,7 +76,7 @@ module Puppet
     def exists?(states = [nil, :found])
       @data = data_parse
       empty_data_check(states)
-      !@resourcetype.find_by(@client, @data).empty?
+      !@resource_type.find_by(@client, @data).empty?
       # @property_hash[:ensure] == :present # TODO: Future Improvement: Look into using property_hash for verifying existance globally
     end
 
@@ -84,9 +84,9 @@ module Puppet
     def create(action = :create)
       return true if resource_update
       ov_resource = if action == :create
-                      @resourcetype.new(@client, @data).create
+                      @resource_type.new(@client, @data).create
                     elsif action == :add
-                      @resourcetype.new(@client, @data).add
+                      @resource_type.new(@client, @data).add
                     else
                       raise 'Invalid action for create'
                     end

--- a/lib/puppet/provider/oneview_san_manager/c7000.rb
+++ b/lib/puppet/provider/oneview_san_manager/c7000.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:oneview_san_manager).provide :c7000, parent: Puppet::OneviewR
     @data = data_parse
     parse_provider_uri
     empty_data_check
-    @resourcetype.find_by(@client, @data).any?
+    @resource_type.find_by(@client, @data).any?
   end
 
   def create

--- a/lib/puppet/provider/oneview_sas_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_sas_interconnect/synergy.rb
@@ -34,10 +34,10 @@ Puppet::Type.type(:oneview_sas_interconnect).provide :synergy, parent: Puppet::O
   def exists?
     @data = data_parse
     empty_data_check([nil, :found, :get_types])
-    return !@resourcetype.find_by(@client, @data).empty? if @data.empty?
+    return !@resource_type.find_by(@client, @data).empty? if @data.empty?
     variable_assignments
     get_single_resource_instance.patch(@patch['op'], @patch['path'], @patch['value']) if @patch
-    @resourcetype.new(@client, @data).exists?
+    @resource_type.new(@client, @data).exists?
   end
 
   def create
@@ -51,9 +51,9 @@ Puppet::Type.type(:oneview_sas_interconnect).provide :synergy, parent: Puppet::O
   def get_types
     Puppet.notice("\n\nSASInterconnect Types\n")
     if @data['name']
-      pretty @resourcetype.get_type(@client, @data['name'])
+      pretty @resource_type.get_type(@client, @data['name'])
     else
-      pretty @resourcetype.get_types(@client)
+      pretty @resource_type.get_types(@client)
     end
     true
   end

--- a/lib/puppet/provider/oneview_sas_logical_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_sas_logical_interconnect/synergy.rb
@@ -35,8 +35,8 @@ Puppet::Type.type(:oneview_sas_logical_interconnect).provide :synergy, parent: P
     @data = data_parse
     empty_data_check
     variable_assignments
-    return !@resourcetype.find_by(@client, @data).empty? unless @data
-    @resourcetype.new(@client, @data).exists?
+    return !@resource_type.find_by(@client, @data).empty? unless @data
+    @resource_type.new(@client, @data).exists?
   end
 
   def create

--- a/lib/puppet/provider/oneview_sas_logical_interconnect_group/synergy.rb
+++ b/lib/puppet/provider/oneview_sas_logical_interconnect_group/synergy.rb
@@ -42,7 +42,7 @@ Puppet::Type.type(:oneview_sas_logical_interconnect_group).provide :synergy, par
     lig = @resourcetype.new(@client, @data)
     add_interconnects(lig) if @interconnects
     @data['new_name'] = new_name if new_name
-    return true if resource_update(@data, @resourcetype)
+    return true if resource_update
     lig.create
     @property_hash[:data] = lig.data
     @property_hash[:ensure] = :present

--- a/lib/puppet/provider/oneview_sas_logical_interconnect_group/synergy.rb
+++ b/lib/puppet/provider/oneview_sas_logical_interconnect_group/synergy.rb
@@ -34,12 +34,12 @@ Puppet::Type.type(:oneview_sas_logical_interconnect_group).provide :synergy, par
   def exists?
     super
     @interconnects = @data.delete('interconnects')
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def create
     new_name = @data.delete('new_name')
-    lig = @resourcetype.new(@client, @data)
+    lig = @resource_type.new(@client, @data)
     add_interconnects(lig) if @interconnects
     @data['new_name'] = new_name if new_name
     return true if resource_update

--- a/lib/puppet/provider/oneview_server_hardware/c7000.rb
+++ b/lib/puppet/provider/oneview_server_hardware/c7000.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:oneview_server_hardware).provide :c7000, parent: Puppet::Onev
     empty_data_check
     data_parse_for_general
     return false if @patch_tags.any?
-    @resourcetype.find_by(@client, @data).any?
+    @resource_type.find_by(@client, @data).any?
   end
 
   def create
@@ -43,7 +43,7 @@ Puppet::Type.type(:oneview_server_hardware).provide :c7000, parent: Puppet::Onev
     return true if resource_update
     @data = @data.merge(@authentication)
     @data['hostname'] = @data.delete('name') if @data['name']
-    ov_resource = @resourcetype.new(@client, @data).add
+    ov_resource = @resource_type.new(@client, @data).add
     @property_hash[:data] = ov_resource.data
     @property_hash[:ensure] = :present
   end

--- a/lib/puppet/provider/oneview_server_hardware/c7000.rb
+++ b/lib/puppet/provider/oneview_server_hardware/c7000.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:oneview_server_hardware).provide :c7000, parent: Puppet::Onev
 
   def create
     return patch unless @patch_tags.empty?
-    return true if resource_update(@data, @resourcetype)
+    return true if resource_update
     @data = @data.merge(@authentication)
     @data['hostname'] = @data.delete('name') if @data['name']
     ov_resource = @resourcetype.new(@client, @data).add

--- a/lib/puppet/provider/oneview_server_hardware_type/c7000.rb
+++ b/lib/puppet/provider/oneview_server_hardware_type/c7000.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:oneview_server_hardware_type).provide :c7000, parent: Puppet:
   mk_resource_methods
 
   def create
-    resource_update(@data, @resourcetype)
+    resource_update
     true
   end
 

--- a/lib/puppet/provider/oneview_server_profile/c7000.rb
+++ b/lib/puppet/provider/oneview_server_profile/c7000.rb
@@ -31,14 +31,14 @@ Puppet::Type.type(:oneview_server_profile).provide :c7000, parent: Puppet::Onevi
     connections_parse if @data['connections']
     # gets the hash of filters for queries; in case it does not exist, query will be nil
     @query = @data.delete('query_parameters')
-    puppet_resource = @resourcetype.new(@client, @data)
+    puppet_resource = @resource_type.new(@client, @data)
     return false unless puppet_resource.retrieve!
     puppet_resource.like?(@data)
   end
 
   # This destroy deletes all the server profiles that match the data passed in. Use with caution.
   def destroy
-    server_profiles = @resourcetype.find_by(@client, @data)
+    server_profiles = @resource_type.find_by(@client, @data)
     raise('There were no matching server profiles in the Appliance.') if server_profiles.empty?
     server_profiles.map(&:delete)
   end
@@ -50,7 +50,7 @@ Puppet::Type.type(:oneview_server_profile).provide :c7000, parent: Puppet::Onevi
 
   def get_available_targets
     Puppet.notice("\n\nServer Profile Available Targets\n")
-    pretty @resourcetype.get_available_targets(@client, @query)
+    pretty @resource_type.get_available_targets(@client, @query)
     true
   end
 
@@ -59,14 +59,14 @@ Puppet::Type.type(:oneview_server_profile).provide :c7000, parent: Puppet::Onevi
     if @data['name'] || @data['uri']
       pretty get_single_resource_instance.get_available_networks
     else
-      pretty @resourcetype.get_available_networks(@client, @query)
+      pretty @resource_type.get_available_networks(@client, @query)
     end
     true
   end
 
   def get_available_servers
     Puppet.notice("\n\nServer Profile Available Targets\n")
-    pretty @resourcetype.get_available_servers(@client, @query)
+    pretty @resource_type.get_available_servers(@client, @query)
     true
   end
 
@@ -74,7 +74,7 @@ Puppet::Type.type(:oneview_server_profile).provide :c7000, parent: Puppet::Onevi
     Puppet.notice("\n\nServer Profile Available Storage Systems\n")
     query_ok = @query['enclosureGroupUri'] && @query['serverHardwareTypeUri']
     raise 'You must specify the following query attributes: enclosureGroupUri and serverHardwareTypeUri.' unless query_ok
-    pretty @resourcetype.get_available_storage_systems(@client, @query)
+    pretty @resource_type.get_available_storage_systems(@client, @query)
     true
   end
 
@@ -83,13 +83,13 @@ Puppet::Type.type(:oneview_server_profile).provide :c7000, parent: Puppet::Onevi
     raise 'You must specify query attributes for this ensure method' unless @query
     query_ok = @query['enclosureGroupUri'] && @query['storageSystemId'] && @query['serverHardwareTypeUri']
     raise 'You must specify the following query attributes: enclosureGroupUri, serverHardwareTypeUri and storageSystemId.' unless query_ok
-    pretty @resourcetype.get_available_storage_system(@client, @query)
+    pretty @resource_type.get_available_storage_system(@client, @query)
     true
   end
 
   def get_profile_ports
     Puppet.notice("\n\nServer Profile Compliance Preview\n")
-    pretty @resourcetype.get_profile_ports(@client, @query)
+    pretty @resource_type.get_profile_ports(@client, @query)
     true
   end
 

--- a/lib/puppet/provider/oneview_server_profile/c7000.rb
+++ b/lib/puppet/provider/oneview_server_profile/c7000.rb
@@ -32,8 +32,7 @@ Puppet::Type.type(:oneview_server_profile).provide :c7000, parent: Puppet::Onevi
     # gets the hash of filters for queries; in case it does not exist, query will be nil
     @query = @data.delete('query_parameters')
     puppet_resource = @resourcetype.new(@client, @data)
-    return false unless puppet_resource.exists?
-    puppet_resource.retrieve!
+    return false unless puppet_resource.retrieve!
     puppet_resource.like?(@data)
   end
 

--- a/lib/puppet/provider/oneview_server_profile/c7000.rb
+++ b/lib/puppet/provider/oneview_server_profile/c7000.rb
@@ -31,7 +31,10 @@ Puppet::Type.type(:oneview_server_profile).provide :c7000, parent: Puppet::Onevi
     connections_parse if @data['connections']
     # gets the hash of filters for queries; in case it does not exist, query will be nil
     @query = @data.delete('query_parameters')
-    !@resourcetype.find_by(@client, @data).empty?
+    puppet_resource = @resourcetype.new(@client, @data)
+    return false unless puppet_resource.exists?
+    puppet_resource.retrieve!
+    puppet_resource.like?(@data)
   end
 
   # This destroy deletes all the server profiles that match the data passed in. Use with caution.

--- a/lib/puppet/provider/oneview_server_profile/synergy.rb
+++ b/lib/puppet/provider/oneview_server_profile/synergy.rb
@@ -23,9 +23,9 @@ Puppet::Type.type(:oneview_server_profile).provide :synergy, parent: :c7000 do
   def get_sas_logical_jbods
     Puppet.notice("\n\nLogical JBOD Attachments\n")
     if @data['name']
-      pretty @resourcetype.get_sas_logical_jbod(@client, @data['name'])
+      pretty @resource_type.get_sas_logical_jbod(@client, @data['name'])
     else
-      pretty @resourcetype.get_sas_logical_jbods(@client)
+      pretty @resource_type.get_sas_logical_jbods(@client)
     end
     true
   end
@@ -33,7 +33,7 @@ Puppet::Type.type(:oneview_server_profile).provide :synergy, parent: :c7000 do
   # Retrieves drives by SAS Logical JBOD name
   def get_sas_logical_jbod_drives
     Puppet.notice("\n\nLogical JBOD Drives\n")
-    pretty @resourcetype.get_sas_logical_jbod_drives(@client, @data['name'])
+    pretty @resource_type.get_sas_logical_jbod_drives(@client, @data['name'])
     true
   end
 
@@ -41,9 +41,9 @@ Puppet::Type.type(:oneview_server_profile).provide :synergy, parent: :c7000 do
   def get_sas_logical_jbod_attachments
     Puppet.notice("\n\nLogical JBOD Attachments\n")
     if @data['name']
-      pretty @resourcetype.get_sas_logical_jbod_attachment(@client, @data['name'])
+      pretty @resource_type.get_sas_logical_jbod_attachment(@client, @data['name'])
     else
-      pretty @resourcetype.get_sas_logical_jbod_attachments(@client)
+      pretty @resource_type.get_sas_logical_jbod_attachments(@client)
     end
     true
   end

--- a/lib/puppet/provider/oneview_server_profile_template/c7000.rb
+++ b/lib/puppet/provider/oneview_server_profile_template/c7000.rb
@@ -26,8 +26,7 @@ Puppet::Type.type(:oneview_server_profile_template).provide :c7000, parent: Pupp
     empty_data_check
     connections_parse if @data['connections']
     puppet_resource = @resourcetype.new(@client, @data)
-    return false unless puppet_resource.exists?
-    puppet_resource.retrieve!
+    return false unless puppet_resource.retrieve!
     puppet_resource.like?(@data)
   end
 

--- a/lib/puppet/provider/oneview_server_profile_template/c7000.rb
+++ b/lib/puppet/provider/oneview_server_profile_template/c7000.rb
@@ -25,7 +25,10 @@ Puppet::Type.type(:oneview_server_profile_template).provide :c7000, parent: Pupp
     @data = data_parse
     empty_data_check
     connections_parse if @data['connections']
-    !@resourcetype.find_by(@client, @data).empty?
+    puppet_resource = @resourcetype.new(@client, @data)
+    return false unless puppet_resource.exists?
+    puppet_resource.retrieve!
+    puppet_resource.like?(@data)
   end
 
   # Creates a new server profile based on the current template

--- a/lib/puppet/provider/oneview_server_profile_template/c7000.rb
+++ b/lib/puppet/provider/oneview_server_profile_template/c7000.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:oneview_server_profile_template).provide :c7000, parent: Pupp
     @data = data_parse
     empty_data_check
     connections_parse if @data['connections']
-    puppet_resource = @resourcetype.new(@client, @data)
+    puppet_resource = @resource_type.new(@client, @data)
     return false unless puppet_resource.retrieve!
     puppet_resource.like?(@data)
   end

--- a/lib/puppet/provider/oneview_storage_pool/c7000.rb
+++ b/lib/puppet/provider/oneview_storage_pool/c7000.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:oneview_storage_pool).provide :c7000, parent: Puppet::Oneview
     super
     # Allows find_by to work in case poolName is declared, since find_by returns it as 'name'
     @data['name'] = @data.delete('poolName') if @data['poolName']
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def create
@@ -44,7 +44,7 @@ Puppet::Type.type(:oneview_storage_pool).provide :c7000, parent: Puppet::Oneview
   end
 
   def setup_for_recreation
-    storage_pool = @resourcetype.find_by(@client, name: @data['name'])
+    storage_pool = @resource_type.find_by(@client, name: @data['name'])
     return true if storage_pool.empty?
     storage_pool.first.remove
     true

--- a/lib/puppet/provider/oneview_storage_system/c7000.rb
+++ b/lib/puppet/provider/oneview_storage_system/c7000.rb
@@ -51,7 +51,7 @@ Puppet::Type.type(:oneview_storage_system).provide :c7000, parent: Puppet::Onevi
   end
 
   def get_host_types
-    pretty @resourcetype.get_host_types(@client)
+    pretty @resource_type.get_host_types(@client)
     true
   end
 end

--- a/lib/puppet/provider/oneview_switch/c7000.rb
+++ b/lib/puppet/provider/oneview_switch/c7000.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:oneview_switch).provide :c7000, parent: Puppet::OneviewResour
     dataless_ensure = [nil, :found, :get_type]
     super(dataless_ensure)
     return true if dataless_ensure.include?(resource['ensure'])
-    !@resourcetype.find_by(@client, unique_id).empty?
+    !@resource_type.find_by(@client, unique_id).empty?
   end
 
   def create
@@ -41,12 +41,12 @@ Puppet::Type.type(:oneview_switch).provide :c7000, parent: Puppet::OneviewResour
   def get_type
     if @data['name']
       Puppet.notice "\n\n Search for switch type #{@data['name']} started, displaying results bellow:\n"
-      results = @resourcetype.get_type(@client, @data['name'])
+      results = @resource_type.get_type(@client, @data['name'])
       raise "\n\n No switch types corresponding to the name #{@data['name']} were found.\n" unless results
       pretty results
     else
       Puppet.notice "\n\n Search for switch types started, displaying results bellow:\n"
-      pretty @resourcetype.get_types(@client)
+      pretty @resource_type.get_types(@client)
     end
     true
   end

--- a/lib/puppet/provider/oneview_switch/synergy.rb
+++ b/lib/puppet/provider/oneview_switch/synergy.rb
@@ -39,12 +39,12 @@ Puppet::Type.type(:oneview_switch).provide :synergy, parent: Puppet::OneviewReso
   def get_type
     if @data['name']
       Puppet.notice "\n\n Search for switch type #{@data['name']} started, displaying results bellow:\n"
-      results = @resourcetype.get_type(@client, @data['name'])
+      results = @resource_type.get_type(@client, @data['name'])
       raise "\n\n No switch types corresponding to the name #{@data['name']} were found.\n" unless results
       pretty results
     else
       Puppet.notice "\n\n Search for switch types started, displaying results bellow:\n"
-      pretty @resourcetype.get_types(@client)
+      pretty @resource_type.get_types(@client)
     end
     true
   end

--- a/lib/puppet/provider/oneview_unmanaged_device/c7000.rb
+++ b/lib/puppet/provider/oneview_unmanaged_device/c7000.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:oneview_unmanaged_device).provide :c7000, parent: Puppet::One
   end
 
   def destroy
-    ud = @resourcetype.find_by(@client, @data)
+    ud = @resource_type.find_by(@client, @data)
     raise('There were no matching Unmanaged Devices in the Appliance.') if ud.empty?
     ud.map(&:remove)
   end

--- a/lib/puppet/provider/oneview_uplink_set/c7000.rb
+++ b/lib/puppet/provider/oneview_uplink_set/c7000.rb
@@ -31,11 +31,11 @@ Puppet::Type.type(:oneview_uplink_set).provide :c7000, parent: Puppet::OneviewRe
     name_to_uris
     # Taking out portConfigInfos before the find_by since it is not returned
     @port_config = @data.delete('portConfigInfos')
-    !@resourcetype.find_by(@client, @data).empty?
+    !@resource_type.find_by(@client, @data).empty?
   end
 
   def create
-    uplink_set = @resourcetype.new(@client, @data)
+    uplink_set = @resource_type.new(@client, @data)
     uplink_set.add_port_config(@port_config[0], @port_config[1], @port_config[2]) if @port_config
     uplink_set.create
     @property_hash[:ensure] = :present

--- a/lib/puppet/provider/oneview_volume/c7000.rb
+++ b/lib/puppet/provider/oneview_volume/c7000.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:oneview_volume).provide :c7000, parent: Puppet::OneviewResour
 
   def create
     return true if resource_update
-    @resourcetype.new(@client, @data).create
+    @resource_type.new(@client, @data).create
     @property_hash[:ensure] = :present
     @property_hash[:data] = @data
     true
@@ -40,7 +40,7 @@ Puppet::Type.type(:oneview_volume).provide :c7000, parent: Puppet::OneviewResour
   def get_attachable_volumes
     Puppet.notice "\n Getting attachable volumes...\n"
     Puppet.notice "\n Displaying list of attachable volumes bellow:\n"
-    pretty @resourcetype.get_attachable_volumes(@client)
+    pretty @resource_type.get_attachable_volumes(@client)
     Puppet.notice "\n <End of the list of attachable volumes>\n"
     true
   end
@@ -48,7 +48,7 @@ Puppet::Type.type(:oneview_volume).provide :c7000, parent: Puppet::OneviewResour
   def get_extra_managed_volume_paths
     Puppet.notice "\n Getting extra managed volume paths...\n"
     Puppet.notice "\n Displaying list of extra managed volume paths bellow:\n"
-    pretty @resourcetype.get_extra_managed_volume_paths(@client)
+    pretty @resource_type.get_extra_managed_volume_paths(@client)
     Puppet.notice "\n <End of the list of attachable volumes>\n"
     true
   end

--- a/lib/puppet/provider/oneview_volume/c7000.rb
+++ b/lib/puppet/provider/oneview_volume/c7000.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:oneview_volume).provide :c7000, parent: Puppet::OneviewResour
   end
 
   def create
-    return true if resource_update(@data, @resourcetype)
+    return true if resource_update
     @resourcetype.new(@client, @data).create
     @property_hash[:ensure] = :present
     @property_hash[:data] = @data

--- a/lib/puppet/provider/oneview_volume_attachment/c7000.rb
+++ b/lib/puppet/provider/oneview_volume_attachment/c7000.rb
@@ -36,14 +36,6 @@ Puppet::Type.type(:oneview_volume_attachment).provide :c7000, parent: Puppet::On
     resource['ensure'].to_s == 'present' ? false : true
   end
 
-  def create
-    raise "Ensure state 'present' is unavailable for this resource"
-  end
-
-  def destroy
-    raise "Ensure state 'absent' is unavailable for this resource"
-  end
-
   def found
     @data.empty? ? find_for_empty : find_for_server_profile
     true
@@ -63,7 +55,6 @@ Puppet::Type.type(:oneview_volume_attachment).provide :c7000, parent: Puppet::On
     server_profile = OneviewSDK::ServerProfile.find_by(@client, name: @data['name']).first
     raise "\n\nSpecified Server Profile does not exist.\n" unless server_profile
     @resource_type.remove_extra_unmanaged_volume(@client, server_profile)
-    # @resource_type.remove_extra_unmanaged_volume(@client, server_profile['uri'])
     true
   end
 

--- a/lib/puppet/provider/oneview_volume_attachment/c7000.rb
+++ b/lib/puppet/provider/oneview_volume_attachment/c7000.rb
@@ -50,7 +50,7 @@ Puppet::Type.type(:oneview_volume_attachment).provide :c7000, parent: Puppet::On
   end
 
   def get_extra_unmanaged_volumes
-    extra_unmanaged_volumes = @resourcetype.get_extra_unmanaged_volumes(@client)['members']
+    extra_unmanaged_volumes = @resource_type.get_extra_unmanaged_volumes(@client)['members']
     raise "\n\nNo Unmanaged volumes were found on the appliance.\n\n" if extra_unmanaged_volumes.empty?
     Puppet.notice "\n\nUnmanaged volumes:\n\n"
     extra_unmanaged_volumes.each do |unmanaged_volume|
@@ -62,8 +62,8 @@ Puppet::Type.type(:oneview_volume_attachment).provide :c7000, parent: Puppet::On
   def remove_extra_unmanaged_volume
     server_profile = OneviewSDK::ServerProfile.find_by(@client, name: @data['name']).first
     raise "\n\nSpecified Server Profile does not exist.\n" unless server_profile
-    @resourcetype.remove_extra_unmanaged_volume(@client, server_profile)
-    # @resourcetype.remove_extra_unmanaged_volume(@client, server_profile['uri'])
+    @resource_type.remove_extra_unmanaged_volume(@client, server_profile)
+    # @resource_type.remove_extra_unmanaged_volume(@client, server_profile['uri'])
     true
   end
 
@@ -96,8 +96,8 @@ Puppet::Type.type(:oneview_volume_attachment).provide :c7000, parent: Puppet::On
   end
 
   def find_for_empty
-    resource_name = @resourcetype.to_s.split('::')
-    vas = @resourcetype.find_by(@client, {})
+    resource_name = @resource_type.to_s.split('::')
+    vas = @resource_type.find_by(@client, {})
     raise "No #{resource_name[1]}s found on the appliance" if vas.empty?
     vas.each do |va|
       Puppet.notice "\n\n Found matching #{resource_name[1]} with the following info: \n"

--- a/lib/puppet/type/oneview_volume_attachment.rb
+++ b/lib/puppet/type/oneview_volume_attachment.rb
@@ -18,8 +18,6 @@ Puppet::Type.newtype(:oneview_volume_attachment) do
   desc "Oneview's Volume Attachment"
 
   ensurable do
-    defaultvalues
-
     # :nocov:
     # Get methods
     newvalue(:found) do

--- a/spec/integration/provider/oneview_volume_attachment_c7000_spec.rb
+++ b/spec/integration/provider/oneview_volume_attachment_c7000_spec.rb
@@ -55,9 +55,6 @@ describe provider_class do
       expect(instance).to be
     end
 
-    it 'should raise an error when the "present" ensurable is specified' do
-      expect { provider.create }.to raise_error(/Ensure state 'present' is unavailable for this resource/)
-    end
     # This requires the VA to be created beforehand
     # it 'should return that the volume attachment was found' do
     #   expect(provider.found).to be
@@ -74,10 +71,6 @@ describe provider_class do
 
     it 'should return the list of paths from the VA' do
       expect(provider.get_paths).to be
-    end
-
-    it 'should raise an error when the "present" ensurable is specified' do
-      expect { provider.destroy }.to raise_error(/Ensure state 'absent' is unavailable for this resource/)
     end
   end
 end

--- a/spec/integration/provider/oneview_volume_attachment_synergy_spec.rb
+++ b/spec/integration/provider/oneview_volume_attachment_synergy_spec.rb
@@ -55,9 +55,6 @@ describe provider_class do
       expect(instance).to be
     end
 
-    it 'should raise an error when the "present" ensurable is specified' do
-      expect { provider.create }.to raise_error(/Ensure state 'present' is unavailable for this resource/)
-    end
     # This requires the VA to be created beforehand
     # it 'should return that the volume attachment was found' do
     #   expect(provider.found).to be
@@ -74,10 +71,6 @@ describe provider_class do
 
     it 'should return the list of paths from the VA' do
       expect(provider.get_paths).to be
-    end
-
-    it 'should raise an error when the "present" ensurable is specified' do
-      expect { provider.destroy }.to raise_error(/Ensure state 'absent' is unavailable for this resource/)
     end
   end
 end

--- a/spec/unit/provider/image_streamer_build_plan_spec.rb
+++ b/spec/unit/provider/image_streamer_build_plan_spec.rb
@@ -23,7 +23,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context Image Streamer'
 
   resource_name = 'BuildPlan'
-  resourcetype = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}")
+  resource_type = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}")
 
   let(:resource) do
     Puppet::Type.type(:image_streamer_build_plan).new(
@@ -42,10 +42,10 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
     provider.exists?
   end
 
@@ -55,8 +55,8 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should run through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
@@ -70,7 +70,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should delete the resource' do
-      allow_any_instance_of(resourcetype).to receive(:delete).and_return([])
+      allow_any_instance_of(resource_type).to receive(:delete).and_return([])
       expect(provider.destroy).to be
     end
   end

--- a/spec/unit/provider/image_streamer_deployment_group_spec.rb
+++ b/spec/unit/provider/image_streamer_deployment_group_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:image_streamer_deployment_group).provider(:image_streamer)
 api_version = login_image_streamer[:api_version] || 300
 resource_name = 'DeploymentGroup'
-resourcetype = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context Image Streamer'
@@ -39,10 +39,10 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
     provider.exists?
   end
 

--- a/spec/unit/provider/image_streamer_deployment_plan_spec.rb
+++ b/spec/unit/provider/image_streamer_deployment_plan_spec.rb
@@ -23,7 +23,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context Image Streamer'
 
   resource_name = 'DeploymentPlan'
-  resourcetype = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}") unless api_version < 300
+  resource_type = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}") unless api_version < 300
 
   build_plan_class = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::BuildPlan")
   golden_image_class = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::GoldenImage")
@@ -47,7 +47,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   let(:buildPlan) { build_plan_class.new(@client, name: resource['data']['oeBuildPlanURI']) }
 
@@ -55,7 +55,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   context 'given the Creation parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       allow(build_plan_class).to receive(:find_by).and_return([buildPlan])
       allow(golden_image_class).to receive(:find_by).and_return([goldenImage])
       provider.exists?
@@ -66,14 +66,14 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should run through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should delete the resource' do
-      allow_any_instance_of(resourcetype).to receive(:delete).and_return([])
+      allow_any_instance_of(resource_type).to receive(:delete).and_return([])
       expect(provider.destroy).to be
     end
 

--- a/spec/unit/provider/image_streamer_golden_image_spec.rb
+++ b/spec/unit/provider/image_streamer_golden_image_spec.rb
@@ -19,14 +19,14 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:image_streamer_golden_image).provider(:image_streamer)
 api_version = login_image_streamer[:api_version] || 300
 resource_name = 'GoldenImage'
-resourcetype = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context Image Streamer'
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   let(:provider) { resource.provider }
 
@@ -47,7 +47,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
 
       build_plan = OneviewSDK::ImageStreamer::BuildPlan.new(@client, 'name' => 'BuildPlanName')
       allow(OneviewSDK::ImageStreamer::BuildPlan).to receive(:find_by).with(anything, name: 'BuildPlanName').and_return([build_plan])
@@ -63,13 +63,13 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should run through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      expect_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      expect_any_instance_of(resource_type).to receive(:create).and_return(test)
       expect(provider.create).to be
     end
 
     it 'should delete the resource' do
-      allow_any_instance_of(resourcetype).to receive(:delete).and_return([])
+      allow_any_instance_of(resource_type).to receive(:delete).and_return([])
       expect(provider.destroy).to be
     end
 
@@ -102,21 +102,21 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
     it 'should upload the file and add the golden image resource with default timeout' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       timeout = OneviewSDK::Rest::READ_TIMEOUT
-      expect(resourcetype).to receive(:add).with(anything, '/path/to/upload/golden_image.zip', expected_data, timeout).and_return(test)
+      expect(resource_type).to receive(:add).with(anything, '/path/to/upload/golden_image.zip', expected_data, timeout).and_return(test)
       expect(provider.create).to be
     end
 
     it 'should upload the file and add the golden image resource with given timeout' do
       resource['data']['timeout'] = 7_200
-      allow(resourcetype).to receive(:find_by).and_return([])
-      expect(resourcetype).to receive(:add).with(anything, '/path/to/upload/golden_image.zip', expected_data, 7_200).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      expect(resource_type).to receive(:add).with(anything, '/path/to/upload/golden_image.zip', expected_data, 7_200).and_return(test)
       expect(provider.create).to be
     end
   end
@@ -137,14 +137,14 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
     context 'when file does not exist' do
       before(:each) do
         allow(File).to receive(:exist?).with(download_path).and_return(false)
-        expect_any_instance_of(resourcetype).to receive(:download_details_archive).with(download_path).and_return(true)
+        expect_any_instance_of(resource_type).to receive(:download_details_archive).with(download_path).and_return(true)
       end
 
       it 'should download the file' do
@@ -168,19 +168,19 @@ describe provider_class, unit: true, if: api_version >= 300 do
       end
 
       it 'should raise error' do
-        expect_any_instance_of(resourcetype).not_to receive(:download_details_archive).and_return(true)
+        expect_any_instance_of(resource_type).not_to receive(:download_details_archive).and_return(true)
         expect { provider.download_details_archive }.to raise_error('File /path/to/download/details_archive.zip already exists.')
       end
 
       it 'should raise error if force is false' do
         resource['data']['force'] = false
-        expect_any_instance_of(resourcetype).not_to receive(:download_details_archive).and_return(true)
+        expect_any_instance_of(resource_type).not_to receive(:download_details_archive).and_return(true)
         expect { provider.download_details_archive }.to raise_error('File /path/to/download/details_archive.zip already exists.')
       end
 
       it 'should download if force is true' do
         resource['data']['force'] = true
-        expect_any_instance_of(resourcetype).to receive(:download_details_archive).with(download_path).and_return(true)
+        expect_any_instance_of(resource_type).to receive(:download_details_archive).with(download_path).and_return(true)
         expect(provider.download_details_archive).to be
       end
     end
@@ -202,14 +202,14 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
     context 'when file does not exist' do
       before(:each) do
         allow(File).to receive(:exist?).with(download_path).and_return(false)
-        expect_any_instance_of(resourcetype).to receive(:download).with(download_path).and_return(true)
+        expect_any_instance_of(resource_type).to receive(:download).with(download_path).and_return(true)
       end
 
       it 'should download the file' do
@@ -233,19 +233,19 @@ describe provider_class, unit: true, if: api_version >= 300 do
       end
 
       it 'should raise error' do
-        expect_any_instance_of(resourcetype).not_to receive(:download).and_return(true)
+        expect_any_instance_of(resource_type).not_to receive(:download).and_return(true)
         expect { provider.download }.to raise_error('File /path/to/download/golden_image.zip already exists.')
       end
 
       it 'should raise error if force is false' do
         resource['data']['force'] = false
-        expect_any_instance_of(resourcetype).not_to receive(:download).and_return(true)
+        expect_any_instance_of(resource_type).not_to receive(:download).and_return(true)
         expect { provider.download }.to raise_error('File /path/to/download/golden_image.zip already exists.')
       end
 
       it 'should download if force is true' do
         resource['data']['force'] = true
-        expect_any_instance_of(resourcetype).to receive(:download).with(download_path).and_return(true)
+        expect_any_instance_of(resource_type).to receive(:download).with(download_path).and_return(true)
         expect(provider.download).to be
       end
     end

--- a/spec/unit/provider/image_streamer_os_volume_spec.rb
+++ b/spec/unit/provider/image_streamer_os_volume_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:image_streamer_os_volume).provider(:image_streamer)
 api_version = login_image_streamer[:api_version] || 300
 resource_name = 'OSVolume'
-resourcetype = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context Image Streamer'
@@ -39,10 +39,10 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
     provider.exists?
   end
 
@@ -68,7 +68,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should retrieve the details of the archived volume' do
-      expect_any_instance_of(resourcetype).to receive(:get_details_archive).and_return(['details of archive'])
+      expect_any_instance_of(resource_type).to receive(:get_details_archive).and_return(['details of archive'])
       expect(provider.get_details_archive).to be
     end
   end

--- a/spec/unit/provider/image_streamer_plan_script_spec.rb
+++ b/spec/unit/provider/image_streamer_plan_script_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:image_streamer_plan_script).provider(:image_streamer)
 api_version = login_image_streamer[:api_version] || 300
 resource_name = 'PlanScript'
-resourcetype = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::ImageStreamer::API#{api_version}::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context Image Streamer'
@@ -43,11 +43,11 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the Creation parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -56,19 +56,19 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should run through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should retrieve differences' do
-      allow_any_instance_of(resourcetype).to receive(:retrieve_differences).and_return(['differences fake response'])
+      allow_any_instance_of(resource_type).to receive(:retrieve_differences).and_return(['differences fake response'])
       expect(provider.retrieve_differences).to be
     end
 
     it 'should delete the resource' do
-      allow_any_instance_of(resourcetype).to receive(:delete).and_return([])
+      allow_any_instance_of(resource_type).to receive(:delete).and_return([])
       expect(provider.destroy).to be
     end
 

--- a/spec/unit/provider/oneview_connection_template_c7000_spec.rb
+++ b/spec/unit/provider/oneview_connection_template_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_connection_template).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:ConnectionTemplate, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:ConnectionTemplate, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_connection_template_c7000_spec.rb
+++ b/spec/unit/provider/oneview_connection_template_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_connection_template).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:ConnectionTemplate, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:ConnectionTemplate, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -40,10 +40,10 @@ describe provider_class, unit: true do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, name: resource['data']['name']) }
+    let(:test) { resource_type.new(@client, name: resource['data']['name']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -53,9 +53,9 @@ describe provider_class, unit: true do
 
     it 'should be able to find the connection template' do
       test['uri'] = '/rest/'
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       provider.exists?
-      allow(resourcetype).to receive(:get_default).with(anything).and_return(test)
+      allow(resource_type).to receive(:get_default).with(anything).and_return(test)
       expect(provider.get_default_connection_template).to be
     end
 

--- a/spec/unit/provider/oneview_connection_template_synergy_spec.rb
+++ b/spec/unit/provider/oneview_connection_template_synergy_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:ConnectionTemplate, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:ConnectionTemplate, api_version, 'Synergy')
 
   context 'given the min parameters' do
     let(:resource) do
@@ -41,10 +41,10 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, name: resource['data']['name']) }
+    let(:test) { resource_type.new(@client, name: resource['data']['name']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -54,9 +54,9 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     it 'should be able to find the connection template' do
       test['uri'] = '/rest/'
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       provider.exists?
-      allow(resourcetype).to receive(:get_default).with(anything).and_return(test)
+      allow(resource_type).to receive(:get_default).with(anything).and_return(test)
       expect(provider.get_default_connection_template).to be
     end
 

--- a/spec/unit/provider/oneview_connection_template_synergy_spec.rb
+++ b/spec/unit/provider/oneview_connection_template_synergy_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_connection_template).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:ConnectionTemplate, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:ConnectionTemplate, api_version, 'Synergy')
 
   context 'given the min parameters' do
     let(:resource) do

--- a/spec/unit/provider/oneview_datacenter_c7000_spec.rb
+++ b/spec/unit/provider/oneview_datacenter_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_datacenter).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:Datacenter, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:Datacenter, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_datacenter_c7000_spec.rb
+++ b/spec/unit/provider/oneview_datacenter_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_datacenter).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:Datacenter, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:Datacenter, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -27,7 +27,7 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the create parameters' do
     let(:resource) do
@@ -49,16 +49,16 @@ describe provider_class, unit: true do
     end
 
     it 'should return that the resource does not exists' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).not_to be
     end
 
     it 'should create/add the datacenter' do
-      expect(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
-      expect(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name'])
+      expect(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([])
+      expect(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name'])
         .and_return([])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:add).and_return(test)
       expect(provider.create).to be
     end
   end
@@ -73,7 +73,7 @@ describe provider_class, unit: true do
     end
 
     it 'should not return any datacenters' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).not_to be
       expect { provider.found }.to raise_error(/No Datacenter with the specified data were found on the Oneview Appliance/)
     end
@@ -93,21 +93,21 @@ describe provider_class, unit: true do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
     it 'should be able to get the visual content' do
       visual_content = 'spec/support/fixtures/unit/provider/datacenter_visual_content.json'
-      allow_any_instance_of(resourcetype).to receive(:get_visual_content).and_return(File.read(visual_content))
+      allow_any_instance_of(resource_type).to receive(:get_visual_content).and_return(File.read(visual_content))
       expect(provider.get_visual_content).to eq(true)
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be

--- a/spec/unit/provider/oneview_datacenter_synergy_spec.rb
+++ b/spec/unit/provider/oneview_datacenter_synergy_spec.rb
@@ -21,13 +21,13 @@ api_version = login[:api_version] || 200
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-  resourcetype = OneviewSDK.resource_named(:Datacenter, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:Datacenter, api_version, 'Synergy')
 
   let(:provider) { resource.provider }
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the create parameters' do
     let(:resource) do
@@ -49,16 +49,16 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should return that the resource does not exists' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).not_to be
     end
 
     it 'should create/add the datacenter' do
-      expect(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
-      expect(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name'])
+      expect(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([])
+      expect(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name'])
         .and_return([])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:add).and_return(test)
       expect(provider.create).to be
     end
   end
@@ -73,7 +73,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should not return any datacenters' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).not_to be
       expect { provider.found }.to raise_error(/No Datacenter with the specified data were found on the Oneview Appliance/)
     end
@@ -93,20 +93,20 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
     it 'should be able to get the visual content' do
       visual_content = 'spec/support/fixtures/unit/provider/datacenter_visual_content.json'
-      allow_any_instance_of(resourcetype).to receive(:get_visual_content).and_return(File.read(visual_content))
+      allow_any_instance_of(resource_type).to receive(:get_visual_content).and_return(File.read(visual_content))
       expect(provider.get_visual_content).to eq(true)
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be

--- a/spec/unit/provider/oneview_datacenter_synergy_spec.rb
+++ b/spec/unit/provider/oneview_datacenter_synergy_spec.rb
@@ -18,10 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_datacenter).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:Datacenter, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-  resource_type = OneviewSDK.resource_named(:Datacenter, api_version, 'Synergy')
 
   let(:provider) { resource.provider }
 

--- a/spec/unit/provider/oneview_drive_enclosure_synergy_spec.rb
+++ b/spec/unit/provider/oneview_drive_enclosure_synergy_spec.rb
@@ -17,12 +17,11 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_drive_enclosure).provider(:synergy)
-api_version = login[:api_version] || 200
+api_version = login[:api_version] || 300
+resource_type = OneviewSDK.resource_named(:DriveEnclosure, api_version, :Synergy)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:DriveEnclosure, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_drive_enclosure).new(

--- a/spec/unit/provider/oneview_drive_enclosure_synergy_spec.rb
+++ b/spec/unit/provider/oneview_drive_enclosure_synergy_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:DriveEnclosure, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:DriveEnclosure, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_drive_enclosure).new(
@@ -47,11 +47,11 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
-    allow_any_instance_of(resourcetype).to receive(:patch).and_return(test)
+    allow(resource_type).to receive(:find_by).and_return([test])
+    allow_any_instance_of(resource_type).to receive(:patch).and_return(test)
     provider.exists?
   end
 
@@ -69,7 +69,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to set the refresh state' do
-      allow_any_instance_of(resourcetype).to receive(:set_refresh_state).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:set_refresh_state).and_return(true)
       expect(provider.set_refresh_state).to be
     end
 

--- a/spec/unit/provider/oneview_enclosure_c7000_spec.rb
+++ b/spec/unit/provider/oneview_enclosure_c7000_spec.rb
@@ -18,9 +18,9 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_enclosure).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:Enclosure, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:Enclosure, api_version, :C7000)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true do
   include_context 'shared context'
 
   let(:provider) { resource.provider }

--- a/spec/unit/provider/oneview_enclosure_c7000_spec.rb
+++ b/spec/unit/provider/oneview_enclosure_c7000_spec.rb
@@ -76,18 +76,22 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       expect(provider.set_refresh_state).to be
     end
 
-    it 'should be able to set the refresh state' do
+    it 'should be able to retrieve utilization statistics' do
       allow_any_instance_of(resourcetype).to receive(:utilization).with(resource['data']['utilization_parameters']).and_return('Test')
       expect(provider.get_utilization).to be
     end
 
-    it 'should be able to set the refresh state' do
+    it 'should be able to get the script from the enclosure' do
       allow_any_instance_of(resourcetype).to receive(:script).and_return('Test')
       expect(provider.get_script).to be
     end
 
-    it 'should be able to set the refresh state' do
+    it '#get_single_sign_on should raise an error' do
       expect { provider.get_single_sign_on }.to raise_error(RuntimeError)
+    end
+
+    it '#set_environmental_configuration should raise an error' do
+      expect { provider.set_environmental_configuration }.to raise_error(RuntimeError)
     end
 
     it 'should be able to work specifying a name instead of an uri' do
@@ -136,17 +140,13 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       end
 
       it 'patches the resource' do
-        unique_id = { 'uri' => '/rest/fake', 'name' => 'Puppet_Test_Enclosure' }
         resource['data']['uri'] = '/rest/fake'
         resource['data']['op'] = 'fake_op'
         resource['data']['path'] = 'fake_path'
         resource['data']['value'] = 'fake_value'
-        patch_data = { 'op' => 'fake_op', 'path' => 'fake_path', 'value' => 'fake_value' }
         test = resourcetype.new(@client, resource['data'])
-        allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-        allow(resourcetype).to receive(:find_by).with(anything, unique_id).and_return([test])
-        expect_any_instance_of(OneviewSDK::Client).to receive(:rest_patch)
-          .with(resource['data']['uri'], { 'body' => [patch_data] }, test.api_version).and_return(FakeResponse.new('uri' => '/rest/fake'))
+        allow(resourcetype).to receive(:find_by).and_return([test])
+        expect_any_instance_of(resourcetype).to receive(:patch).and_return(true)
         provider.exists?
         expect(provider.create).to be
       end

--- a/spec/unit/provider/oneview_enclosure_c7000_spec.rb
+++ b/spec/unit/provider/oneview_enclosure_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_enclosure).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:Enclosure, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:Enclosure, api_version, 'C7000')
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
@@ -27,7 +27,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   let(:resource) do
     Puppet::Type.type(:oneview_enclosure).new(
@@ -53,7 +53,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   context 'given the min parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
@@ -62,27 +62,27 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to get the environmental configuration' do
-      allow_any_instance_of(resourcetype).to receive(:environmental_configuration).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:environmental_configuration).and_return('Test')
       expect(provider.get_environmental_configuration).to be
     end
 
     it 'should be able to set the configuration' do
-      allow_any_instance_of(resourcetype).to receive(:configuration).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:configuration).and_return('Test')
       expect(provider.set_configuration).to be
     end
 
     it 'should be able to set the refresh state' do
-      allow_any_instance_of(resourcetype).to receive(:set_refresh_state).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:set_refresh_state).and_return('Test')
       expect(provider.set_refresh_state).to be
     end
 
     it 'should be able to retrieve utilization statistics' do
-      allow_any_instance_of(resourcetype).to receive(:utilization).with(resource['data']['utilization_parameters']).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:utilization).with(resource['data']['utilization_parameters']).and_return('Test')
       expect(provider.get_utilization).to be
     end
 
     it 'should be able to get the script from the enclosure' do
-      allow_any_instance_of(resourcetype).to receive(:script).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:script).and_return('Test')
       expect(provider.get_script).to be
     end
 
@@ -96,17 +96,17 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
     it 'should be able to work specifying a name instead of an uri' do
       resource['data']['enclosureGroupUri'] = 'Test'
-      test = resourcetype.new(@client, resource['data'])
+      test = resource_type.new(@client, resource['data'])
       allow(OneviewSDK::EnclosureGroup).to receive(:find_by).with(anything, name: resource['data']['enclosureGroupUri']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be
@@ -131,10 +131,10 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       end
 
       it 'creates the resource' do
-        allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
-        allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([])
-        allow(resourcetype).to receive(:find_by).with(anything, uri: '/rest/fake').and_return([test])
-        allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+        allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([])
+        allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([])
+        allow(resource_type).to receive(:find_by).with(anything, uri: '/rest/fake').and_return([test])
+        allow_any_instance_of(resource_type).to receive(:add).and_return(test)
         provider.exists?
         expect(provider.create).to be
       end
@@ -144,9 +144,9 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
         resource['data']['op'] = 'fake_op'
         resource['data']['path'] = 'fake_path'
         resource['data']['value'] = 'fake_value'
-        test = resourcetype.new(@client, resource['data'])
-        allow(resourcetype).to receive(:find_by).and_return([test])
-        expect_any_instance_of(resourcetype).to receive(:patch).and_return(true)
+        test = resource_type.new(@client, resource['data'])
+        allow(resource_type).to receive(:find_by).and_return([test])
+        expect_any_instance_of(resource_type).to receive(:patch).and_return(true)
         provider.exists?
         expect(provider.create).to be
       end

--- a/spec/unit/provider/oneview_enclosure_group_c7000_spec.rb
+++ b/spec/unit/provider/oneview_enclosure_group_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_enclosure_group).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:EnclosureGroup, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:EnclosureGroup, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -77,10 +77,10 @@ describe provider_class, unit: true do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -89,30 +89,30 @@ describe provider_class, unit: true do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be
     end
 
     it 'should be able to get the script' do
-      allow_any_instance_of(resourcetype).to receive(:get_script).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_script).and_return('Test')
       expect(provider.get_script).to be
     end
 
     it 'should be able to set the script' do
       resource['data']['script'] = 'Sample'
-      allow_any_instance_of(resourcetype).to receive(:set_script).with('Sample').and_return('Sample')
+      allow_any_instance_of(resource_type).to receive(:set_script).with('Sample').and_return('Sample')
       expect(provider.set_script).to be
     end
   end

--- a/spec/unit/provider/oneview_enclosure_group_c7000_spec.rb
+++ b/spec/unit/provider/oneview_enclosure_group_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_enclosure_group).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:EnclosureGroup, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:EnclosureGroup, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_enclosure_group_synergy_spec.rb
+++ b/spec/unit/provider/oneview_enclosure_group_synergy_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:EnclosureGroup, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:EnclosureGroup, api_version, 'Synergy')
 
   context 'given the create parameters' do
     let(:resource) do
@@ -78,10 +78,10 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -90,29 +90,29 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be
     end
 
     it 'should be able to get the script' do
-      allow_any_instance_of(resourcetype).to receive(:get_script).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_script).and_return('Test')
       expect(provider.get_script).to be
     end
 
     it 'should be able to set the script' do
       resource['data']['script'] = 'Sample'
-      allow_any_instance_of(resourcetype).to receive(:set_script).with('Sample').and_return('Sample')
+      allow_any_instance_of(resource_type).to receive(:set_script).with('Sample').and_return('Sample')
       expect(provider.set_script).to be
     end
   end

--- a/spec/unit/provider/oneview_enclosure_group_synergy_spec.rb
+++ b/spec/unit/provider/oneview_enclosure_group_synergy_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_enclosure_group).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:EnclosureGroup, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:EnclosureGroup, api_version, 'Synergy')
 
   context 'given the create parameters' do
     let(:resource) do

--- a/spec/unit/provider/oneview_enclosure_synergy_spec.rb
+++ b/spec/unit/provider/oneview_enclosure_synergy_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_enclosure).provider(:synergy)
 api_version = login[:api_version] || 200
+resourcetype = OneviewSDK.resource_named(:Enclosure, api_version, 'Synergy')
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
-
-  resourcetype = OneviewSDK.resource_named(:Enclosure, api_version, 'Synergy')
 
   let(:provider) { resource.provider }
 
@@ -77,18 +76,22 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       expect(provider.set_refresh_state).to be
     end
 
-    it 'should be able to set the refresh state' do
+    it 'should be able to retrieve utilization statistics' do
       allow_any_instance_of(resourcetype).to receive(:utilization).with(resource['data']['utilization_parameters']).and_return('Test')
       expect(provider.get_utilization).to be
     end
 
-    it 'should be able to set the refresh state' do
+    it 'should be able to get the script from the enclosure' do
       allow_any_instance_of(resourcetype).to receive(:script).and_return('Test')
       expect(provider.get_script).to be
     end
 
-    it 'should be able to set the refresh state' do
+    it '#get_single_sign_on should raise an error' do
       expect { provider.get_single_sign_on }.to raise_error(RuntimeError)
+    end
+
+    it '#set_environmental_configuration should raise an error' do
+      expect { provider.set_environmental_configuration }.to raise_error(RuntimeError)
     end
 
     it 'should be able to work specifying a name instead of an uri' do
@@ -128,24 +131,22 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       end
 
       it 'creates the resource' do
+        allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
         allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([])
+        allow(resourcetype).to receive(:find_by).with(anything, uri: '/rest/fake').and_return([test])
         allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
         provider.exists?
         expect(provider.create).to be
       end
 
       it 'patches the resource' do
-        unique_id = { 'uri' => '/rest/fake', 'name' => 'Puppet_Test_Enclosure' }
         resource['data']['uri'] = '/rest/fake'
         resource['data']['op'] = 'fake_op'
         resource['data']['path'] = 'fake_path'
         resource['data']['value'] = 'fake_value'
-        patch_data = { 'op' => 'fake_op', 'path' => 'fake_path', 'value' => 'fake_value' }
         test = resourcetype.new(@client, resource['data'])
-        allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-        allow(resourcetype).to receive(:find_by).with(anything, unique_id).and_return([test])
-        expect_any_instance_of(OneviewSDK::Client).to receive(:rest_patch)
-          .with(resource['data']['uri'], { 'body' => [patch_data] }, test.api_version).and_return(FakeResponse.new('uri' => '/rest/fake'))
+        allow(resourcetype).to receive(:find_by).and_return([test])
+        expect_any_instance_of(resourcetype).to receive(:patch).and_return(true)
         provider.exists?
         expect(provider.create).to be
       end

--- a/spec/unit/provider/oneview_enclosure_synergy_spec.rb
+++ b/spec/unit/provider/oneview_enclosure_synergy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_enclosure).provider(:synergy)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:Enclosure, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:Enclosure, api_version, 'Synergy')
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
@@ -27,7 +27,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   let(:resource) do
     Puppet::Type.type(:oneview_enclosure).new(
@@ -53,7 +53,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   context 'given the min parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
@@ -62,27 +62,27 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to get the environmental configuration' do
-      allow_any_instance_of(resourcetype).to receive(:environmental_configuration).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:environmental_configuration).and_return('Test')
       expect(provider.get_environmental_configuration).to be
     end
 
     it 'should be able to set the configuration' do
-      allow_any_instance_of(resourcetype).to receive(:configuration).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:configuration).and_return('Test')
       expect(provider.set_configuration).to be
     end
 
     it 'should be able to set the refresh state' do
-      allow_any_instance_of(resourcetype).to receive(:set_refresh_state).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:set_refresh_state).and_return('Test')
       expect(provider.set_refresh_state).to be
     end
 
     it 'should be able to retrieve utilization statistics' do
-      allow_any_instance_of(resourcetype).to receive(:utilization).with(resource['data']['utilization_parameters']).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:utilization).with(resource['data']['utilization_parameters']).and_return('Test')
       expect(provider.get_utilization).to be
     end
 
     it 'should be able to get the script from the enclosure' do
-      allow_any_instance_of(resourcetype).to receive(:script).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:script).and_return('Test')
       expect(provider.get_script).to be
     end
 
@@ -96,17 +96,17 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
     it 'should be able to work specifying a name instead of an uri' do
       resource['data']['enclosureGroupUri'] = 'Test'
-      test = resourcetype.new(@client, resource['data'])
+      test = resource_type.new(@client, resource['data'])
       allow(OneviewSDK::EnclosureGroup).to receive(:find_by).with(anything, name: resource['data']['enclosureGroupUri']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be
@@ -131,10 +131,10 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       end
 
       it 'creates the resource' do
-        allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
-        allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([])
-        allow(resourcetype).to receive(:find_by).with(anything, uri: '/rest/fake').and_return([test])
-        allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+        allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([])
+        allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([])
+        allow(resource_type).to receive(:find_by).with(anything, uri: '/rest/fake').and_return([test])
+        allow_any_instance_of(resource_type).to receive(:add).and_return(test)
         provider.exists?
         expect(provider.create).to be
       end
@@ -144,9 +144,9 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
         resource['data']['op'] = 'fake_op'
         resource['data']['path'] = 'fake_path'
         resource['data']['value'] = 'fake_value'
-        test = resourcetype.new(@client, resource['data'])
-        allow(resourcetype).to receive(:find_by).and_return([test])
-        expect_any_instance_of(resourcetype).to receive(:patch).and_return(true)
+        test = resource_type.new(@client, resource['data'])
+        allow(resource_type).to receive(:find_by).and_return([test])
+        expect_any_instance_of(resource_type).to receive(:patch).and_return(true)
         provider.exists?
         expect(provider.create).to be
       end

--- a/spec/unit/provider/oneview_enclosure_synergy_spec.rb
+++ b/spec/unit/provider/oneview_enclosure_synergy_spec.rb
@@ -18,9 +18,9 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_enclosure).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:Enclosure, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:Enclosure, api_version, :Synergy)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   let(:provider) { resource.provider }

--- a/spec/unit/provider/oneview_ethernet_network_c7000_spec.rb
+++ b/spec/unit/provider/oneview_ethernet_network_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_ethernet_network).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:EthernetNetwork, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:EthernetNetwork, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_ethernet_network_c7000_spec.rb
+++ b/spec/unit/provider/oneview_ethernet_network_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_ethernet_network).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:EthernetNetwork, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:EthernetNetwork, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -45,11 +45,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the create parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -58,17 +58,17 @@ describe provider_class, unit: true do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be
@@ -76,46 +76,46 @@ describe provider_class, unit: true do
 
     it 'should be able to get the associated uplink groups' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_associated_uplink_groups).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_associated_uplink_groups).and_return('Test')
       expect(provider.get_associated_uplink_groups).to be
     end
 
     it 'should raise a warning when there are no associated uplink groups to show' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_associated_uplink_groups).and_return('[]')
+      allow_any_instance_of(resource_type).to receive(:get_associated_uplink_groups).and_return('[]')
       expect(provider.get_associated_uplink_groups).to be
     end
 
     it 'should be able to get the associated profiles' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_associated_profiles).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_associated_profiles).and_return('Test')
       expect(provider.get_associated_profiles).to be
     end
 
     it 'should be able to get the associated profiles' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_associated_profiles).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_associated_profiles).and_return('Test')
       expect(provider.get_associated_profiles).to be
     end
 
     it 'should raise a warning when its not able to get the associated profiles' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_associated_profiles).and_return('[]')
+      allow_any_instance_of(resource_type).to receive(:get_associated_profiles).and_return('[]')
       expect(provider.get_associated_profiles).to be
     end
 
@@ -124,9 +124,9 @@ describe provider_class, unit: true do
       resource['data']['connectionTemplateUri'] = '/rest/fake'
       resource['data']['bandwidth'] = { 'maximumbandwidth' => '1000' }
       unique_ids = { 'uri' => '/rest/fake', 'name' => 'Puppet Network' }
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, unique_ids).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, unique_ids).and_return([test])
       allow(OneviewSDK::ConnectionTemplate).to receive(:get_default).with(anything).and_return(test)
       allow(OneviewSDK::ConnectionTemplate).to receive(:find_by)
         .with(anything, uri: resource['data']['connectionTemplateUri']).and_return([test])

--- a/spec/unit/provider/oneview_ethernet_network_synergy_spec.rb
+++ b/spec/unit/provider/oneview_ethernet_network_synergy_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_ethernet_network).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:EthernetNetwork, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:EthernetNetwork, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_ethernet_network).new(

--- a/spec/unit/provider/oneview_ethernet_network_synergy_spec.rb
+++ b/spec/unit/provider/oneview_ethernet_network_synergy_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:EthernetNetwork, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:EthernetNetwork, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_ethernet_network).new(
@@ -46,11 +46,11 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the create parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -59,16 +59,16 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be
@@ -76,46 +76,46 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     it 'should be able to get the associated uplink groups' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_associated_uplink_groups).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_associated_uplink_groups).and_return('Test')
       expect(provider.get_associated_uplink_groups).to be
     end
 
     it 'should raise a warning when there are no associated uplink groups to show' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_associated_uplink_groups).and_return('[]')
+      allow_any_instance_of(resource_type).to receive(:get_associated_uplink_groups).and_return('[]')
       expect(provider.get_associated_uplink_groups).to be
     end
 
     it 'should be able to get the associated profiles' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_associated_profiles).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_associated_profiles).and_return('Test')
       expect(provider.get_associated_profiles).to be
     end
 
     it 'should be able to get the associated profiles' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_associated_profiles).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_associated_profiles).and_return('Test')
       expect(provider.get_associated_profiles).to be
     end
 
     it 'should raise a warning when its not able to get the associated profiles' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_associated_profiles).and_return('[]')
+      allow_any_instance_of(resource_type).to receive(:get_associated_profiles).and_return('[]')
       expect(provider.get_associated_profiles).to be
     end
 
@@ -124,9 +124,9 @@ describe provider_class, unit: true, if: api_version >= 300 do
       resource['data']['connectionTemplateUri'] = '/rest/fake'
       resource['data']['bandwidth'] = { 'maximumbandwidth' => '1000' }
       unique_ids = { 'uri' => '/rest/fake', 'name' => 'Puppet Network' }
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, unique_ids).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, unique_ids).and_return([test])
       allow(OneviewSDK::ConnectionTemplate).to receive(:get_default).with(anything).and_return(test)
       allow(OneviewSDK::ConnectionTemplate).to receive(:find_by)
         .with(anything, uri: resource['data']['connectionTemplateUri']).and_return([test])

--- a/spec/unit/provider/oneview_fabric_c7000_spec.rb
+++ b/spec/unit/provider/oneview_fabric_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_fabric).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:Fabric, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:Fabric, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_fabric_c7000_spec.rb
+++ b/spec/unit/provider/oneview_fabric_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_fabric).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:Fabric, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:Fabric, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -40,10 +40,10 @@ describe provider_class, unit: true do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 

--- a/spec/unit/provider/oneview_fabric_synergy_spec.rb
+++ b/spec/unit/provider/oneview_fabric_synergy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_fabric).provider(:synergy)
 api_version = login[:api_version] || 300
-resourcetype = OneviewSDK.resource_named(:Fabric, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:Fabric, api_version, 'Synergy')
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
@@ -40,10 +40,10 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -61,12 +61,12 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should be able to get_reserved_vlan_range' do
-      allow_any_instance_of(resourcetype).to receive(:get_reserved_vlan_range).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:get_reserved_vlan_range).and_return(true)
       expect(provider.get_reserved_vlan_range).to be
     end
 
     it 'should be able to set_reserved_vlan_range' do
-      allow_any_instance_of(resourcetype).to receive(:set_reserved_vlan_range).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:set_reserved_vlan_range).and_return(true)
       expect(provider.set_reserved_vlan_range).to be
     end
   end

--- a/spec/unit/provider/oneview_fabric_synergy_spec.rb
+++ b/spec/unit/provider/oneview_fabric_synergy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_fabric).provider(:synergy)
 api_version = login[:api_version] || 300
-resource_type = OneviewSDK.resource_named(:Fabric, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:Fabric, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_fc_network_c7000_spec.rb
+++ b/spec/unit/provider/oneview_fc_network_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_fc_network).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:FCNetwork, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:FCNetwork, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_fc_network_c7000_spec.rb
+++ b/spec/unit/provider/oneview_fc_network_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_fc_network).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:FCNetwork, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:FCNetwork, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -43,11 +43,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the Creation parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -56,27 +56,27 @@ describe provider_class, unit: true do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      allow(resourcetype).to receive(:find_by).and_return([test])
-      allow_any_instance_of(resourcetype).to receive(:delete).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([test])
+      allow_any_instance_of(resource_type).to receive(:delete).and_return([])
       provider.exists?
       expect(provider.destroy).to be
     end
 
     it 'should be able to run through self.instances' do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       expect(instance).to be
     end
 
     it 'finds the resource' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
       expect(provider.found).to be
     end

--- a/spec/unit/provider/oneview_fc_network_synergy_spec.rb
+++ b/spec/unit/provider/oneview_fc_network_synergy_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_fc_network).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:FCNetwork, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:FCNetwork, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_fc_network).new(

--- a/spec/unit/provider/oneview_fc_network_synergy_spec.rb
+++ b/spec/unit/provider/oneview_fc_network_synergy_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:FCNetwork, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:FCNetwork, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_fc_network).new(
@@ -44,11 +44,11 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the Creation parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -57,27 +57,27 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      allow(resourcetype).to receive(:find_by).and_return([test])
-      allow_any_instance_of(resourcetype).to receive(:delete).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([test])
+      allow_any_instance_of(resource_type).to receive(:delete).and_return([])
       provider.exists?
       expect(provider.destroy).to be
     end
 
     it 'should be able to run through self.instances' do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       expect(instance).to be
     end
 
     it 'finds the resource' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
       expect(provider.found).to be
     end

--- a/spec/unit/provider/oneview_fcoe_network_c7000_spec.rb
+++ b/spec/unit/provider/oneview_fcoe_network_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_fcoe_network).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:FCoENetwork, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:FCoENetwork, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_fcoe_network_c7000_spec.rb
+++ b/spec/unit/provider/oneview_fcoe_network_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_fcoe_network).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:FCoENetwork, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:FCoENetwork, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -43,10 +43,10 @@ describe provider_class, unit: true do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -55,22 +55,22 @@ describe provider_class, unit: true do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to run through self.instances' do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       expect(instance).to be
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be

--- a/spec/unit/provider/oneview_fcoe_network_synergy_spec.rb
+++ b/spec/unit/provider/oneview_fcoe_network_synergy_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:FCoENetwork, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:FCoENetwork, api_version, 'Synergy')
 
   context 'given the create parameters' do
     let(:resource) do
@@ -44,10 +44,10 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -56,22 +56,22 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to run through self.instances' do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       expect(instance).to be
     end
 
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['name']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be

--- a/spec/unit/provider/oneview_fcoe_network_synergy_spec.rb
+++ b/spec/unit/provider/oneview_fcoe_network_synergy_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_fcoe_network).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:FCoENetwork, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:FCoENetwork, api_version, 'Synergy')
 
   context 'given the create parameters' do
     let(:resource) do

--- a/spec/unit/provider/oneview_firmware_bundle_c7000_spec.rb
+++ b/spec/unit/provider/oneview_firmware_bundle_c7000_spec.rb
@@ -1,0 +1,65 @@
+################################################################################
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:oneview_firmware_bundle).provider(:c7000)
+api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:FirmwareBundle, api_version, :C7000)
+
+describe provider_class, unit: true do
+  include_context 'shared context'
+
+  let(:resource) do
+    Puppet::Type.type(:oneview_firmware_bundle).new(
+      name: 'firmware_bundle',
+      ensure: 'present',
+      data:
+          {
+            'firmware_bundle_path' => './spec/support/test_firmware_bundle.spp'
+          },
+      provider: 'c7000'
+    )
+  end
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  context 'given the minimum parameters' do
+    before(:each) do
+      allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return('test')
+      provider.exists?
+    end
+
+    it 'should be an instance of the provider oneview_firmware_bundle' do
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_bundle).provider(:c7000)
+    end
+
+    it 'should raise error when firmware bundle is not found' do
+      expect { provider.found }.to raise_error(/"Found" is not a valid ensurable for firmware bundle./)
+    end
+
+    it 'should raise an error since the destroy operation is not supported' do
+      expect { provider.destroy }.to raise_error(/"Absent" is not a valid ensurable for firmware bundle./)
+    end
+
+    it 'should create/add the firmware bundle' do
+      allow(resource_type).to receive(:add).and_return(resource)
+      expect(provider.create).to be
+    end
+  end
+end

--- a/spec/unit/provider/oneview_firmware_bundle_spec.rb
+++ b/spec/unit/provider/oneview_firmware_bundle_spec.rb
@@ -20,7 +20,7 @@ provider_class = Puppet::Type.type(:oneview_firmware_bundle).provider(:c7000)
 
 api_version = login[:api_version] || 200
 resource_name = 'FirmwareBundle'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
@@ -60,7 +60,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should create/add the firmware bundle' do
-      allow(resourcetype).to receive(:add).and_return(resource)
+      allow(resource_type).to receive(:add).and_return(resource)
       expect(provider.create).to be
     end
   end

--- a/spec/unit/provider/oneview_firmware_bundle_synergy_spec.rb
+++ b/spec/unit/provider/oneview_firmware_bundle_synergy_spec.rb
@@ -16,11 +16,9 @@
 
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:oneview_firmware_bundle).provider(:c7000)
-
+provider_class = Puppet::Type.type(:oneview_firmware_bundle).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_name = 'FirmwareBundle'
-resource_type = Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}") unless api_version < 300
+resource_type = OneviewSDK.resource_named(:FirmwareBundle, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
@@ -33,7 +31,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
           {
             'firmware_bundle_path' => './spec/support/test_firmware_bundle.spp'
           },
-      provider: 'c7000'
+      provider: 'synergy'
     )
   end
 
@@ -48,7 +46,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should be an instance of the provider oneview_firmware_bundle' do
-      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_bundle).provider(:c7000)
+      expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_firmware_bundle).provider(:synergy)
     end
 
     it 'should raise error when firmware bundle is not found' do

--- a/spec/unit/provider/oneview_firmware_driver_c7000_spec.rb
+++ b/spec/unit/provider/oneview_firmware_driver_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_firmware_driver).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:FirmwareDriver, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:FirmwareDriver, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -39,7 +39,7 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters' do
     it 'should be an instance of the provider oneview_firmware_driver' do
@@ -47,7 +47,7 @@ describe provider_class, unit: true do
     end
 
     it 'should raise error when Firmware Driver is not found' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect { provider.found }.to raise_error(/No FirmwareDriver with the specified data were found on the Oneview Appliance/)
     end
   end
@@ -68,12 +68,12 @@ describe provider_class, unit: true do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['customBaselineName'])
+      allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['customBaselineName'])
         .and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['baselineUri']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['hotfixUris'][0]).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']).and_return([])
-      allow(resourcetype).to receive(:get_all).with(anything).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, name: resource['data']['baselineUri']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, name: resource['data']['hotfixUris'][0]).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, name: resource['data']).and_return([])
+      allow(resource_type).to receive(:get_all).with(anything).and_return([test])
       provider.exists?
     end
 
@@ -82,25 +82,25 @@ describe provider_class, unit: true do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should delete the Firmware Driver' do
       resource['data']['uri'] = '/rest/firmware-drivers/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.destroy).to be
     end
 
     it 'should be able to work specifying a name instead of an uri' do
       resource['data']['baselineUri'] = 'Test'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['baselineUri']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, name: resource['data']['baselineUri']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
     end
   end

--- a/spec/unit/provider/oneview_firmware_driver_c7000_spec.rb
+++ b/spec/unit/provider/oneview_firmware_driver_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_firmware_driver).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:FirmwareDriver, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:FirmwareDriver, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_firmware_driver_synergy_spec.rb
+++ b/spec/unit/provider/oneview_firmware_driver_synergy_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:FirmwareDriver, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:FirmwareDriver, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_firmware_driver).new(
@@ -40,7 +40,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters' do
     it 'should be an instance of the provider oneview_firmware_driver' do
@@ -48,7 +48,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should raise error when Firmware Driver is not found' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect { provider.found }.to raise_error(/No FirmwareDriver with the specified data were found on the Oneview Appliance/)
     end
   end
@@ -69,12 +69,12 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).with(anything, 'name' => resource['data']['customBaselineName'])
+      allow(resource_type).to receive(:find_by).with(anything, 'name' => resource['data']['customBaselineName'])
         .and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['baselineUri']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['hotfixUris'][0]).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']).and_return([])
-      allow(resourcetype).to receive(:get_all).with(anything).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, name: resource['data']['baselineUri']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, name: resource['data']['hotfixUris'][0]).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, name: resource['data']).and_return([])
+      allow(resource_type).to receive(:get_all).with(anything).and_return([test])
       provider.exists?
     end
 
@@ -83,25 +83,25 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should delete the Firmware Driver' do
       resource['data']['uri'] = '/rest/firmware-drivers/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.destroy).to be
     end
 
     it 'should be able to work specifying a name instead of an uri' do
       resource['data']['baselineUri'] = '/rest/firmware-drivers/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['baselineUri']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, name: resource['data']['baselineUri']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
     end
   end

--- a/spec/unit/provider/oneview_firmware_driver_synergy_spec.rb
+++ b/spec/unit/provider/oneview_firmware_driver_synergy_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_firmware_driver).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:FirmwareDriver, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:FirmwareDriver, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_firmware_driver).new(

--- a/spec/unit/provider/oneview_interconnect_c7000_spec.rb
+++ b/spec/unit/provider/oneview_interconnect_c7000_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:Interconnect, api_version, 'C7000')
+  resource_type = OneviewSDK.resource_named(:Interconnect, api_version, 'C7000')
 
   let(:resource) do
     Puppet::Type.type(:oneview_interconnect).new(
@@ -47,11 +47,11 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the min parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -60,32 +60,32 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to find the interconnects' do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       expect(provider.found).to be
     end
 
     it 'should be able to get the name servers' do
-      allow_any_instance_of(resourcetype).to receive(:name_servers).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:name_servers).and_return('Test')
       expect(provider.get_name_servers).to be
     end
 
     it 'should be able to get the types filtered by a name' do
-      allow(resourcetype).to receive(:get_type).and_return('Test')
+      allow(resource_type).to receive(:get_type).and_return('Test')
       expect(provider.get_types).to be
     end
 
     it 'should be able to get the statistics' do
-      allow_any_instance_of(resourcetype).to receive(:statistics).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:statistics).and_return('Test')
       expect(provider.get_statistics).to be
     end
 
     it 'should be able to reset the port protection' do
-      allow_any_instance_of(resourcetype).to receive(:reset_port_protection).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:reset_port_protection).and_return('Test')
       expect(provider.reset_port_protection).to be
     end
 
     it 'should be able to update the ports' do
-      allow_any_instance_of(resourcetype).to receive(:update_port).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:update_port).and_return('Test')
       expect(provider.update_ports).to be
     end
 

--- a/spec/unit/provider/oneview_interconnect_c7000_spec.rb
+++ b/spec/unit/provider/oneview_interconnect_c7000_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_interconnect).provider(:c7000)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:Interconnect, api_version, :C7000)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:Interconnect, api_version, 'C7000')
 
   let(:resource) do
     Puppet::Type.type(:oneview_interconnect).new(

--- a/spec/unit/provider/oneview_interconnect_synergy_spec.rb
+++ b/spec/unit/provider/oneview_interconnect_synergy_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_interconnect).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:Interconnect, api_version, :Synergy)
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:Interconnect, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_interconnect).new(

--- a/spec/unit/provider/oneview_interconnect_synergy_spec.rb
+++ b/spec/unit/provider/oneview_interconnect_synergy_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:Interconnect, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:Interconnect, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_interconnect).new(
@@ -47,11 +47,11 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the min parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -60,12 +60,12 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to get the name servers' do
-      allow_any_instance_of(resourcetype).to receive(:name_servers).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:name_servers).and_return('Test')
       expect(provider.get_name_servers).to be
     end
 
     it 'should be able to get the statistics' do
-      allow_any_instance_of(resourcetype).to receive(:statistics).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:statistics).and_return('Test')
       expect(provider.get_statistics).to be
     end
 
@@ -73,23 +73,23 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       resource['data']['statistics'] = {}
       resource['data']['statistics']['portName'] = 'portname'
       resource['data']['statistics']['subportNumber'] = 'subportname'
-      allow_any_instance_of(resourcetype).to receive(:statistics).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:statistics).and_return('Test')
       provider.exists?
       expect(provider.get_statistics).to be
     end
 
     it 'should be able to reset the port protection' do
-      allow_any_instance_of(resourcetype).to receive(:reset_port_protection).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:reset_port_protection).and_return('Test')
       expect(provider.reset_port_protection).to be
     end
 
     it 'should be able to update the ports' do
-      allow(resourcetype).to receive(:update_port).and_return('Test')
+      allow(resource_type).to receive(:update_port).and_return('Test')
       expect(provider.update_ports).to be
     end
 
     it 'should be able to get the link topologies' do
-      allow(resourcetype).to receive(:get_link_topologies).and_return(['Test'])
+      allow(resource_type).to receive(:get_link_topologies).and_return(['Test'])
       expect(provider.get_link_topologies).to be
     end
 
@@ -100,7 +100,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   context 'given the min parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       provider.exists?
     end
 
@@ -113,12 +113,12 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to get all the link topologies' do
-      allow(resourcetype).to receive(:get_link_topologies).and_return(['Test'])
+      allow(resource_type).to receive(:get_link_topologies).and_return(['Test'])
       expect(provider.get_link_topologies).to be
     end
 
     it 'should be able to get all the link topologies' do
-      allow(resourcetype).to receive(:get_types).and_return(['Test'])
+      allow(resource_type).to receive(:get_types).and_return(['Test'])
       expect(provider.get_types).to be
     end
   end

--- a/spec/unit/provider/oneview_logical_downlink_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_downlink_c7000_spec.rb
@@ -83,7 +83,7 @@ describe provider_class, unit: true do
       expect { provider.get_without_ethernet }.to raise_error(/The method #get_without_ethernet is unavailable for this resource/)
     end
 
-    it 'should raise error when running get without ethernet - Test disabled due to bug on oneview-sdk' do
+    it 'should raise error when running get without ethernet' do
       resource['data'] = {}
       provider.exists?
       expect { provider.get_without_ethernet }.to raise_error(/The method #self.get_without_ethernet is unavailable for this resource/)

--- a/spec/unit/provider/oneview_logical_downlink_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_downlink_c7000_spec.rb
@@ -83,7 +83,7 @@ describe provider_class, unit: true do
       expect { provider.get_without_ethernet }.to raise_error(/The method #get_without_ethernet is unavailable for this resource/)
     end
 
-    xit 'should raise error when running get without ethernet - Test disabled due to bug on oneview-sdk' do
+    it 'should raise error when running get without ethernet - Test disabled due to bug on oneview-sdk' do
       resource['data'] = {}
       provider.exists?
       expect { provider.get_without_ethernet }.to raise_error(/The method #self.get_without_ethernet is unavailable for this resource/)

--- a/spec/unit/provider/oneview_logical_downlink_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_downlink_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_logical_downlink).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:LogicalDownlink, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:LogicalDownlink, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -39,10 +39,10 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
     provider.exists?
   end
 
@@ -75,7 +75,7 @@ describe provider_class, unit: true do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -104,12 +104,12 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to get logical downlinks without ethernet' do
-      allow_any_instance_of(resourcetype).to receive(:get_without_ethernet).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:get_without_ethernet).and_return(test)
       expect(provider.get_without_ethernet).to be
     end
 
     it 'should be able to get all the logical downlinks without ethernet' do
-      allow(resourcetype).to receive(:get_without_ethernet).and_return([test])
+      allow(resource_type).to receive(:get_without_ethernet).and_return([test])
       resource['data'] = {}
       provider.exists?
       expect(provider.get_without_ethernet).to be

--- a/spec/unit/provider/oneview_logical_downlink_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_downlink_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_logical_downlink).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:LogicalDownlink, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:LogicalDownlink, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_logical_downlink_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_downlink_synergy_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:LogicalDownlink, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:LogicalDownlink, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_logical_downlink).new(
@@ -40,10 +40,10 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
     provider.exists?
   end
 
@@ -76,7 +76,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 

--- a/spec/unit/provider/oneview_logical_downlink_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_downlink_synergy_spec.rb
@@ -84,7 +84,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
       expect { provider.get_without_ethernet }.to raise_error(/The method #get_without_ethernet is unavailable for this resource/)
     end
 
-    it 'should raise error when running get without ethernet - Test disabled due to bug on oneview-sdk' do
+    it 'should raise error when running get without ethernet' do
       resource['data'] = {}
       provider.exists?
       expect { provider.get_without_ethernet }.to raise_error(/The method #self.get_without_ethernet is unavailable for this resource/)

--- a/spec/unit/provider/oneview_logical_downlink_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_downlink_synergy_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_logical_downlink).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:LogicalDownlink, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:LogicalDownlink, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_logical_downlink).new(

--- a/spec/unit/provider/oneview_logical_downlink_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_downlink_synergy_spec.rb
@@ -84,7 +84,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
       expect { provider.get_without_ethernet }.to raise_error(/The method #get_without_ethernet is unavailable for this resource/)
     end
 
-    xit 'should raise error when running get without ethernet - Test disabled due to bug on oneview-sdk' do
+    it 'should raise error when running get without ethernet - Test disabled due to bug on oneview-sdk' do
       resource['data'] = {}
       provider.exists?
       expect { provider.get_without_ethernet }.to raise_error(/The method #self.get_without_ethernet is unavailable for this resource/)

--- a/spec/unit/provider/oneview_logical_enclosure_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_enclosure_c7000_spec.rb
@@ -17,7 +17,8 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_logical_enclosure).provider(:c7000)
-resource_type = OneviewSDK::LogicalEnclosure
+api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:LogicalEnclosure, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_logical_enclosure_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_enclosure_c7000_spec.rb
@@ -17,7 +17,7 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_logical_enclosure).provider(:c7000)
-resourcetype = OneviewSDK::LogicalEnclosure
+resource_type = OneviewSDK::LogicalEnclosure
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -42,11 +42,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the Creation parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -55,7 +55,7 @@ describe provider_class, unit: true do
     end
 
     it 'if nothing is found should return false' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
@@ -64,14 +64,14 @@ describe provider_class, unit: true do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'deletes the resource' do
-      expect_any_instance_of(resourcetype).to receive(:delete).and_return([])
+      expect_any_instance_of(resource_type).to receive(:delete).and_return([])
       provider.exists?
       expect(provider.destroy).to be
     end
@@ -85,24 +85,24 @@ describe provider_class, unit: true do
     end
 
     it '#gets the script' do
-      allow_any_instance_of(resourcetype).to receive(:get_script).and_return('')
+      allow_any_instance_of(resource_type).to receive(:get_script).and_return('')
       expect(provider.get_script).to be
     end
 
     it '#sets the script on the logical enclosure' do
       resource['data']['script'] = 'Random text script'
-      allow_any_instance_of(resourcetype).to receive(:set_script).and_return('')
+      allow_any_instance_of(resource_type).to receive(:set_script).and_return('')
       expect(provider.set_script).to be
     end
 
     it '#updates the logical enclosure from group -- ~refreshes it' do
-      allow_any_instance_of(resourcetype).to receive(:update_from_group).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:update_from_group).and_return(true)
       expect(provider.updated_from_group).to be
     end
 
     it '#generates a support dump for the logical enclosure' do
       resource['data']['dump'] = 'Random text for dump'
-      allow_any_instance_of(resourcetype).to receive(:support_dump).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:support_dump).and_return(true)
       expect(provider.generate_support_dump).to be
     end
   end

--- a/spec/unit/provider/oneview_logical_enclosure_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_enclosure_synergy_spec.rb
@@ -17,7 +17,7 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_logical_enclosure).provider(:synergy)
-resourcetype = OneviewSDK::LogicalEnclosure
+resource_type = OneviewSDK::LogicalEnclosure
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -42,11 +42,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the Creation parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -55,7 +55,7 @@ describe provider_class, unit: true do
     end
 
     it 'if nothing is found should return false' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
@@ -64,14 +64,14 @@ describe provider_class, unit: true do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'deletes the resource' do
-      expect_any_instance_of(resourcetype).to receive(:delete).and_return([])
+      expect_any_instance_of(resource_type).to receive(:delete).and_return([])
       provider.exists?
       expect(provider.destroy).to be
     end
@@ -85,7 +85,7 @@ describe provider_class, unit: true do
     end
 
     it '#gets the script' do
-      allow_any_instance_of(resourcetype).to receive(:get_script).and_return('')
+      allow_any_instance_of(resource_type).to receive(:get_script).and_return('')
       expect(provider.get_script).to be
     end
 
@@ -94,13 +94,13 @@ describe provider_class, unit: true do
     end
 
     it '#updates the logical enclosure from group -- ~refreshes it' do
-      allow_any_instance_of(resourcetype).to receive(:update_from_group).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:update_from_group).and_return(true)
       expect(provider.updated_from_group).to be
     end
 
     it '#generates a support dump for the logical enclosure' do
       resource['data']['dump'] = 'Random text for dump'
-      allow_any_instance_of(resourcetype).to receive(:support_dump).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:support_dump).and_return(true)
       expect(provider.generate_support_dump).to be
     end
   end

--- a/spec/unit/provider/oneview_logical_enclosure_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_enclosure_synergy_spec.rb
@@ -17,9 +17,10 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_logical_enclosure).provider(:synergy)
-resource_type = OneviewSDK::LogicalEnclosure
+api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:LogicalEnclosure, api_version, :Synergy)
 
-describe provider_class, unit: true do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   let(:resource) do

--- a/spec/unit/provider/oneview_logical_interconnect_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_c7000_spec.rb
@@ -19,7 +19,7 @@ require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_logical_interconnect).provider(:c7000)
-resourcetype = OneviewSDK::LogicalInterconnect
+resource_type = OneviewSDK::LogicalInterconnect
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -62,8 +62,8 @@ describe provider_class, unit: true do
 
   context 'given the min parameters' do
     before(:each) do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
@@ -73,7 +73,7 @@ describe provider_class, unit: true do
     end
 
     it 'return false when the resource does not exists' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
@@ -82,67 +82,67 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to get the qos configuration' do
-      allow_any_instance_of(resourcetype).to receive(:get_qos_aggregated_configuration).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_qos_aggregated_configuration).and_return('Test')
       expect(provider.get_qos_aggregated_configuration).to be
     end
 
     it 'should be able to get the port monitor' do
-      allow_any_instance_of(resourcetype).to receive(:get_port_monitor).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_port_monitor).and_return('Test')
       expect(provider.get_port_monitor).to be
     end
 
     it 'should be able to get the firmware' do
-      allow_any_instance_of(resourcetype).to receive(:get_firmware).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_firmware).and_return('Test')
       expect(provider.get_firmware).to be
     end
 
     it 'should be able to get the vlans' do
       test_network = OneviewSDK::EthernetNetwork.new(@client, name: 'NET')
       allow(OneviewSDK::EthernetNetwork).to receive(:find_by).with(anything, name: 'NET').and_return([test_network])
-      allow_any_instance_of(resourcetype).to receive(:list_vlan_networks).and_return([test_network])
+      allow_any_instance_of(resource_type).to receive(:list_vlan_networks).and_return([test_network])
       expect(provider.get_internal_vlans).to be
     end
 
     it 'should be able to get the snmp configuration' do
-      allow_any_instance_of(resourcetype).to receive(:get_snmp_configuration).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_snmp_configuration).and_return('Test')
       expect(provider.get_snmp_configuration).to be
     end
 
     it 'should be able to add an internal network' do
       test_network = OneviewSDK::EthernetNetwork.new(@client, name: 'NET')
       allow(OneviewSDK::EthernetNetwork).to receive(:find_by).with(anything, name: 'NET').and_return([test_network])
-      expect_any_instance_of(resourcetype).to receive(:update_internal_networks)
+      expect_any_instance_of(resource_type).to receive(:update_internal_networks)
         .with(test_network).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_internal_networks).to be
     end
 
     it 'should be able to set the compliance' do
-      expect_any_instance_of(resourcetype).to receive(:compliance).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:compliance).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_compliance).to be
     end
 
     it 'should be able to update the snmp configuration' do
-      expect_any_instance_of(resourcetype).to receive(:update_snmp_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:update_snmp_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_snmp_configuration).to be
     end
 
     it 'should be able to update the port monitor' do
-      expect_any_instance_of(resourcetype).to receive(:update_port_monitor).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:update_port_monitor).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_port_monitor).to be
     end
 
     it 'should be able to set the configuration' do
-      expect_any_instance_of(resourcetype).to receive(:configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_configuration).to be
     end
 
     it 'should be able to set the telemetry configuration' do
-      expect_any_instance_of(resourcetype).to receive(:update_telemetry_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:update_telemetry_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_telemetry_configuration).to be
     end
 
     it 'should be able to set the qos configuration' do
-      expect_any_instance_of(resourcetype).to receive(:update_qos_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:update_qos_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_qos_aggregated_configuration).to be
     end
   end
@@ -161,8 +161,8 @@ describe provider_class, unit: true do
     end
 
     before(:each) do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 

--- a/spec/unit/provider/oneview_logical_interconnect_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_c7000_spec.rb
@@ -19,7 +19,8 @@ require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_logical_interconnect).provider(:c7000)
-resource_type = OneviewSDK::LogicalInterconnect
+api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:LogicalInterconnect, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_logical_interconnect_group_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_group_c7000_spec.rb
@@ -20,9 +20,9 @@ require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_logical_interconnect_group).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type ||= OneviewSDK.resource_named(:LogicalInterconnectGroup, api_version, 'C7000')
-ethtype ||= OneviewSDK.resource_named(:EthernetNetwork, api_version, 'C7000')
-interconnect_type ||= OneviewSDK.resource_named(:Interconnect, api_version, 'C7000')
+resource_type ||= OneviewSDK.resource_named(:LogicalInterconnectGroup, api_version, :C7000)
+ethtype ||= OneviewSDK.resource_named(:EthernetNetwork, api_version, :C7000)
+interconnect_type ||= OneviewSDK.resource_named(:Interconnect, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_logical_interconnect_group_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_group_c7000_spec.rb
@@ -20,7 +20,7 @@ require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_logical_interconnect_group).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype ||= OneviewSDK.resource_named(:LogicalInterconnectGroup, api_version, 'C7000')
+resource_type ||= OneviewSDK.resource_named(:LogicalInterconnectGroup, api_version, 'C7000')
 ethtype ||= OneviewSDK.resource_named(:EthernetNetwork, api_version, 'C7000')
 interconnect_type ||= OneviewSDK.resource_named(:Interconnect, api_version, 'C7000')
 
@@ -46,11 +46,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the min parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -59,18 +59,18 @@ describe provider_class, unit: true do
     end
 
     it 'return false when the resource does not exists' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
     it 'should be able to get the default settings' do
       provider.exists?
-      allow(resourcetype).to receive(:get_default_settings).and_return('Test')
+      allow(resource_type).to receive(:get_default_settings).and_return('Test')
       expect(provider.get_default_settings).to be
     end
 
     it 'should be able to get the settings' do
-      allow_any_instance_of(resourcetype).to receive(:get_settings).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_settings).and_return('Test')
       expect(provider.get_settings).to be
     end
 
@@ -79,7 +79,7 @@ describe provider_class, unit: true do
     end
 
     it 'deletes the resource' do
-      expect_any_instance_of(resourcetype).to receive(:delete).and_return([])
+      expect_any_instance_of(resource_type).to receive(:delete).and_return([])
       expect(provider.destroy).to be
     end
   end
@@ -128,15 +128,15 @@ describe provider_class, unit: true do
     end
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       allow(ethtype).to receive(:find_by).and_return([ethtype.new(@client, name: 'fake_eth', uri: '/rest/fake_uri')])
       allow(interconnect_type).to receive(:get_type).and_return('uri' => '/fake/interconnect_type_uri')
       provider.exists?
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end

--- a/spec/unit/provider/oneview_logical_interconnect_group_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_group_synergy_spec.rb
@@ -22,7 +22,7 @@ provider_class = Puppet::Type.type(:oneview_logical_interconnect_group).provider
 api_version = login[:api_version] || 300
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
-  resourcetype ||= OneviewSDK.resource_named(:LogicalInterconnectGroup, api_version, 'Synergy')
+  resource_type ||= OneviewSDK.resource_named(:LogicalInterconnectGroup, api_version, 'Synergy')
   interconnect_type ||= OneviewSDK.resource_named(:Interconnect, api_version, 'Synergy')
 
   include_context 'shared context'
@@ -56,11 +56,11 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the min parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       allow(interconnect_type).to receive(:get_type).and_return('uri' => '/fake/interconnect_type_uri')
       provider.exists?
     end
@@ -70,16 +70,16 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'return false when the resource does not exists' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       allow(OneviewSDK::EthernetNetwork).to receive(:find_by)
         .and_return([OneviewSDK::EthernetNetwork.new(@client, name: 'testnet', uri: '/rest/fakenet')])
-      allow_any_instance_of(resourcetype).to receive(:add_interconnect).and_return('')
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:add_interconnect).and_return('')
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       resource['data']['interconnects'] = [{ 'bay' => 1, 'type' => 'HP VC FlexFabric 10Gb/24-Port Module' }]
       resource['data']['internalNetworkUris'] = [%w(testnet1 testnet2)]
       provider.exists?
@@ -87,12 +87,12 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to get the default settings' do
-      allow(resourcetype).to receive(:get_default_settings).and_return('Test')
+      allow(resource_type).to receive(:get_default_settings).and_return('Test')
       expect(provider.get_default_settings).to be
     end
 
     it 'should be able to get the settings' do
-      allow_any_instance_of(resourcetype).to receive(:get_settings).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_settings).and_return('Test')
       expect(provider.get_settings).to be
     end
 
@@ -101,7 +101,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'deletes the resource' do
-      expect_any_instance_of(resourcetype).to receive(:delete).and_return([])
+      expect_any_instance_of(resource_type).to receive(:delete).and_return([])
       expect(provider.destroy).to be
     end
   end

--- a/spec/unit/provider/oneview_logical_interconnect_group_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_group_synergy_spec.rb
@@ -19,12 +19,11 @@ require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_logical_interconnect_group).provider(:synergy)
-api_version = login[:api_version] || 300
+api_version = login[:api_version] || 200
+resource_type ||= OneviewSDK.resource_named(:LogicalInterconnectGroup, api_version, :Synergy)
+interconnect_type ||= OneviewSDK.resource_named(:Interconnect, api_version, :Synergy)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
-  resource_type ||= OneviewSDK.resource_named(:LogicalInterconnectGroup, api_version, 'Synergy')
-  interconnect_type ||= OneviewSDK.resource_named(:Interconnect, api_version, 'Synergy')
-
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   let(:resource) do

--- a/spec/unit/provider/oneview_logical_interconnect_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_synergy_spec.rb
@@ -19,7 +19,7 @@ require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_logical_interconnect).provider(:synergy)
-resourcetype = OneviewSDK::LogicalInterconnect
+resource_type = OneviewSDK::LogicalInterconnect
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
@@ -62,8 +62,8 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   context 'given the min parameters' do
     before(:each) do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
@@ -73,7 +73,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'return false when the resource does not exists' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
@@ -82,67 +82,67 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to get the qos configuration' do
-      allow_any_instance_of(resourcetype).to receive(:get_qos_aggregated_configuration).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_qos_aggregated_configuration).and_return('Test')
       expect(provider.get_qos_aggregated_configuration).to be
     end
 
     it 'should be able to get the port monitor' do
-      allow_any_instance_of(resourcetype).to receive(:get_port_monitor).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_port_monitor).and_return('Test')
       expect(provider.get_port_monitor).to be
     end
 
     it 'should be able to get the firmware' do
-      allow_any_instance_of(resourcetype).to receive(:get_firmware).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_firmware).and_return('Test')
       expect(provider.get_firmware).to be
     end
 
     it 'should be able to get the vlans' do
       test_network = OneviewSDK::EthernetNetwork.new(@client, name: 'NET')
       allow(OneviewSDK::EthernetNetwork).to receive(:find_by).with(anything, name: 'NET').and_return([test_network])
-      allow_any_instance_of(resourcetype).to receive(:list_vlan_networks).and_return([test_network])
+      allow_any_instance_of(resource_type).to receive(:list_vlan_networks).and_return([test_network])
       expect(provider.get_internal_vlans).to be
     end
 
     it 'should be able to get the snmp configuration' do
-      allow_any_instance_of(resourcetype).to receive(:get_snmp_configuration).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_snmp_configuration).and_return('Test')
       expect(provider.get_snmp_configuration).to be
     end
 
     it 'should be able to add an internal network' do
       test_network = OneviewSDK::EthernetNetwork.new(@client, name: 'NET')
       allow(OneviewSDK::EthernetNetwork).to receive(:find_by).with(anything, name: 'NET').and_return([test_network])
-      expect_any_instance_of(resourcetype).to receive(:update_internal_networks)
+      expect_any_instance_of(resource_type).to receive(:update_internal_networks)
         .with(test_network).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_internal_networks).to be
     end
 
     it 'should be able to set the compliance' do
-      expect_any_instance_of(resourcetype).to receive(:compliance).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:compliance).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_compliance).to be
     end
 
     it 'should be able to update the snmp configuration' do
-      expect_any_instance_of(resourcetype).to receive(:update_snmp_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:update_snmp_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_snmp_configuration).to be
     end
 
     it 'should be able to update the port monitor' do
-      expect_any_instance_of(resourcetype).to receive(:update_port_monitor).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:update_port_monitor).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_port_monitor).to be
     end
 
     it 'should be able to set the configuration' do
-      expect_any_instance_of(resourcetype).to receive(:configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_configuration).to be
     end
 
     it 'should be able to set the telemetry configuration' do
-      expect_any_instance_of(resourcetype).to receive(:update_telemetry_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:update_telemetry_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_telemetry_configuration).to be
     end
 
     it 'should be able to set the qos configuration' do
-      expect_any_instance_of(resourcetype).to receive(:update_qos_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:update_qos_configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_qos_aggregated_configuration).to be
     end
   end
@@ -161,8 +161,8 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     before(:each) do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 

--- a/spec/unit/provider/oneview_logical_interconnect_synergy_spec.rb
+++ b/spec/unit/provider/oneview_logical_interconnect_synergy_spec.rb
@@ -19,9 +19,10 @@ require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_logical_interconnect).provider(:synergy)
-resource_type = OneviewSDK::LogicalInterconnect
+api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:LogicalInterconnect, api_version, :Synergy)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   let(:resource) do

--- a/spec/unit/provider/oneview_logical_switch_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_switch_c7000_spec.rb
@@ -18,14 +18,9 @@ require 'spec_helper'
 require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
-provider_class = Puppet::Type.type(:oneview_logical_switch).provider(:oneview_logical_switch)
+provider_class = Puppet::Type.type(:oneview_logical_switch).provider(:c7000)
 api_version = login[:api_version] || 200
-@resource_name = 'LogicalSwitch'
-resource_type ||= if api_version == 200
-                    Object.const_get("OneviewSDK::API#{api_version}::#{@resource_name}")
-                  else
-                    Object.const_get("OneviewSDK::API#{api_version}::C7000::#{@resource_name}")
-                  end
+resource_type = OneviewSDK.resource_named(:LogicalSwitch, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_logical_switch_group_c7000_spec.rb
+++ b/spec/unit/provider/oneview_logical_switch_group_c7000_spec.rb
@@ -18,14 +18,9 @@ require 'spec_helper'
 require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
-provider_class = Puppet::Type.type(:oneview_logical_switch_group).provider(:oneview_logical_switch_group)
+provider_class = Puppet::Type.type(:oneview_logical_switch_group).provider(:c7000)
 api_version = login[:api_version] || 200
-@resource_name = 'LogicalSwitchGroup'
-resource_type ||= if api_version == 200
-                    Object.const_get("OneviewSDK::API#{api_version}::#{@resource_name}")
-                  else
-                    Object.const_get("OneviewSDK::API#{api_version}::C7000::#{@resource_name}")
-                  end
+resource_type = OneviewSDK.resource_named(:LogicalSwitchGroup, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_logical_switch_group_spec.rb
+++ b/spec/unit/provider/oneview_logical_switch_group_spec.rb
@@ -21,11 +21,11 @@ require_relative '../../shared_context'
 provider_class = Puppet::Type.type(:oneview_logical_switch_group).provider(:oneview_logical_switch_group)
 api_version = login[:api_version] || 200
 @resource_name = 'LogicalSwitchGroup'
-resourcetype ||= if api_version == 200
-                   Object.const_get("OneviewSDK::API#{api_version}::#{@resource_name}")
-                 else
-                   Object.const_get("OneviewSDK::API#{api_version}::C7000::#{@resource_name}")
-                 end
+resource_type ||= if api_version == 200
+                    Object.const_get("OneviewSDK::API#{api_version}::#{@resource_name}")
+                  else
+                    Object.const_get("OneviewSDK::API#{api_version}::C7000::#{@resource_name}")
+                  end
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -53,10 +53,10 @@ describe provider_class, unit: true do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -69,7 +69,7 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to delete the resource' do
-      allow_any_instance_of(resourcetype).to receive(:delete).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:delete).and_return(true)
       expect(provider.destroy).to be
     end
 
@@ -78,9 +78,9 @@ describe provider_class, unit: true do
     end
 
     it 'successfully runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:set_grouping_parameters).with(1, 'Cisco Nexus 50xx').and_return(test)
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:set_grouping_parameters).with(1, 'Cisco Nexus 50xx').and_return(test)
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end

--- a/spec/unit/provider/oneview_logical_switch_spec.rb
+++ b/spec/unit/provider/oneview_logical_switch_spec.rb
@@ -21,11 +21,11 @@ require_relative '../../shared_context'
 provider_class = Puppet::Type.type(:oneview_logical_switch).provider(:oneview_logical_switch)
 api_version = login[:api_version] || 200
 @resource_name = 'LogicalSwitch'
-resourcetype ||= if api_version == 200
-                   Object.const_get("OneviewSDK::API#{api_version}::#{@resource_name}")
-                 else
-                   Object.const_get("OneviewSDK::API#{api_version}::C7000::#{@resource_name}")
-                 end
+resource_type ||= if api_version == 200
+                    Object.const_get("OneviewSDK::API#{api_version}::#{@resource_name}")
+                  else
+                    Object.const_get("OneviewSDK::API#{api_version}::C7000::#{@resource_name}")
+                  end
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -64,11 +64,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, name: resource['data']['name']) }
+  let(:test) { resource_type.new(@client, name: resource['data']['name']) }
 
   context 'given the min parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -81,13 +81,13 @@ describe provider_class, unit: true do
     end
 
     it 'should refresh the logical switch' do
-      allow_any_instance_of(resourcetype).to receive(:refresh).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:refresh).and_return(true)
       expect(provider.refresh).to be
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(resourcetype.new(@client, resource['data']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(resource_type.new(@client, resource['data']))
       expect(provider.create).to be
     end
 

--- a/spec/unit/provider/oneview_managed_san_c7000_spec.rb
+++ b/spec/unit/provider/oneview_managed_san_c7000_spec.rb
@@ -19,11 +19,11 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:oneview_managed_san).provider(:c7000)
 api_version = login[:api_version] || 200
 resource_name = 'ManagedSAN'
-resourcetype = if api_version == 200
-                 Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-               else
-                 Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-               end
+resource_type = if api_version == 200
+                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
+                else
+                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
+                end
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -44,11 +44,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
-    allow(resourcetype).to receive(:get_all).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:get_all).and_return([test])
     provider.exists?
   end
 
@@ -83,8 +83,8 @@ describe provider_class, unit: true do
       )
     end
     it 'should create/add the managed san' do
-      allow_any_instance_of(resourcetype).to receive(:set_public_attributes).and_return(test)
-      allow_any_instance_of(resourcetype).to receive(:set_san_policy).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:set_public_attributes).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:set_san_policy).and_return(test)
       expect(provider.create).to be
     end
 
@@ -93,13 +93,13 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to run through get_zoning_report' do
-      allow_any_instance_of(resourcetype).to receive(:get_zoning_report).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:get_zoning_report).and_return(true)
       expect(provider.get_zoning_report).to be
     end
 
     it 'should be able to run through set_refresh_state' do
       resource['data']['refreshState'] = 'RefreshPending'
-      allow_any_instance_of(resourcetype).to receive(:set_refresh_state).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:set_refresh_state).and_return(true)
       expect(provider.set_refresh_state).to be
     end
   end
@@ -110,7 +110,7 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to run through get_endpoints' do
-      allow_any_instance_of(resourcetype).to receive(:get_endpoints).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:get_endpoints).and_return(true)
       expect(provider.get_endpoints).to be
     end
 

--- a/spec/unit/provider/oneview_managed_san_c7000_spec.rb
+++ b/spec/unit/provider/oneview_managed_san_c7000_spec.rb
@@ -18,12 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_managed_san).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_name = 'ManagedSAN'
-resource_type = if api_version == 200
-                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-                else
-                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-                end
+resource_type = OneviewSDK.resource_named(:ManagedSAN, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_managed_san_synergy_spec.rb
+++ b/spec/unit/provider/oneview_managed_san_synergy_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:oneview_managed_san).provider(:synergy)
 api_version = login[:api_version] || 200
 resource_name = 'ManagedSAN'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
@@ -40,11 +40,11 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
-    allow(resourcetype).to receive(:get_all).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:get_all).and_return([test])
     provider.exists?
   end
 
@@ -79,8 +79,8 @@ describe provider_class, unit: true, if: api_version >= 300 do
       )
     end
     it 'should create/add the managed san' do
-      allow_any_instance_of(resourcetype).to receive(:set_public_attributes).and_return(test)
-      allow_any_instance_of(resourcetype).to receive(:set_san_policy).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:set_public_attributes).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:set_san_policy).and_return(test)
       expect(provider.create).to be
     end
 
@@ -89,13 +89,13 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should be able to run through get_zoning_report' do
-      allow_any_instance_of(resourcetype).to receive(:get_zoning_report).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:get_zoning_report).and_return(true)
       expect(provider.get_zoning_report).to be
     end
 
     it 'should be able to run through set_refresh_state' do
       resource['data']['refreshState'] = 'RefreshPending'
-      allow_any_instance_of(resourcetype).to receive(:set_refresh_state).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:set_refresh_state).and_return(true)
       expect(provider.set_refresh_state).to be
     end
   end
@@ -106,7 +106,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should be able to run through get_endpoints' do
-      allow_any_instance_of(resourcetype).to receive(:get_endpoints).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:get_endpoints).and_return(true)
       expect(provider.get_endpoints).to be
     end
 

--- a/spec/unit/provider/oneview_managed_san_synergy_spec.rb
+++ b/spec/unit/provider/oneview_managed_san_synergy_spec.rb
@@ -18,8 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_managed_san).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_name = 'ManagedSAN'
-resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = OneviewSDK.resource_named(:ManagedSAN, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_network_set_c7000_spec.rb
+++ b/spec/unit/provider/oneview_network_set_c7000_spec.rb
@@ -18,10 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_network_set).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:NetworkSet, api_version, 'C7000')
-ethernet_class = OneviewSDK.resource_named(:EthernetNetwork, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:NetworkSet, api_version, :C7000)
+ethernet_class = OneviewSDK.resource_named(:EthernetNetwork, api_version, :C7000)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true do
   include_context 'shared context'
 
   context 'given the standard parameters' do

--- a/spec/unit/provider/oneview_network_set_c7000_spec.rb
+++ b/spec/unit/provider/oneview_network_set_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_network_set).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:NetworkSet, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:NetworkSet, api_version, 'C7000')
 ethernet_class = OneviewSDK.resource_named(:EthernetNetwork, api_version, 'C7000')
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
@@ -42,12 +42,12 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, name: resource['data']['name']) }
+    let(:test) { resource_type.new(@client, name: resource['data']['name']) }
 
     let(:eth1) { ethernet_class.new(@client, name: resource['data']['networkUris'].first) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       allow(ethernet_class).to receive(:find_by).and_return([eth1])
       provider.exists?
     end
@@ -57,7 +57,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should return that the resource does not exists' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
@@ -66,20 +66,20 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
 
     it 'should be able to delete the resource' do
       resource['data']['uri'] = '/rest/fake'
-      allow_any_instance_of(resourcetype).to receive(:delete).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:delete).and_return(true)
       expect(provider.destroy).to be
     end
 
     it 'should be able to get all the network sets without ethernet' do
-      allow_any_instance_of(resourcetype).to receive(:get_without_ethernet).and_return([test])
+      allow_any_instance_of(resource_type).to receive(:get_without_ethernet).and_return([test])
       expect(provider.get_without_ethernet).to be
     end
   end
@@ -94,15 +94,15 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
     let(:provider) { resource.provider }
 
-    let(:test) { resourcetype.new(@client, {}) }
+    let(:test) { resource_type.new(@client, {}) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
     it 'should be able to get all the network sets without ethernet' do
-      allow(resourcetype).to receive(:get_without_ethernet).and_return([test])
+      allow(resource_type).to receive(:get_without_ethernet).and_return([test])
       expect(provider.get_without_ethernet).to be
     end
   end

--- a/spec/unit/provider/oneview_network_set_synergy_spec.rb
+++ b/spec/unit/provider/oneview_network_set_synergy_spec.rb
@@ -18,8 +18,8 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_network_set).provider(:synergy)
 api_version = login[:api_version] || 300
-resource_type = OneviewSDK.resource_named(:NetworkSet, api_version, 'Synergy')
-ethernet_class = OneviewSDK.resource_named(:EthernetNetwork, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:NetworkSet, api_version, :Synergy)
+ethernet_class = OneviewSDK.resource_named(:EthernetNetwork, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_network_set_synergy_spec.rb
+++ b/spec/unit/provider/oneview_network_set_synergy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_network_set).provider(:synergy)
 api_version = login[:api_version] || 300
-resourcetype = OneviewSDK.resource_named(:NetworkSet, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:NetworkSet, api_version, 'Synergy')
 ethernet_class = OneviewSDK.resource_named(:EthernetNetwork, api_version, 'Synergy')
 
 describe provider_class, unit: true, if: api_version >= 300 do
@@ -42,12 +42,12 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, name: resource['data']['name']) }
+    let(:test) { resource_type.new(@client, name: resource['data']['name']) }
 
     let(:eth1) { ethernet_class.new(@client, name: resource['data']['networkUris'].first) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       allow(ethernet_class).to receive(:find_by).and_return([eth1])
       provider.exists?
     end
@@ -57,7 +57,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should return that the resource does not exists' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
@@ -66,20 +66,20 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
 
     it 'should be able to delete the resource' do
       resource['data']['uri'] = '/rest/fake'
-      allow_any_instance_of(resourcetype).to receive(:delete).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:delete).and_return(true)
       expect(provider.destroy).to be
     end
 
     it 'should be able to get all the network sets without ethernet' do
-      allow_any_instance_of(resourcetype).to receive(:get_without_ethernet).and_return([test])
+      allow_any_instance_of(resource_type).to receive(:get_without_ethernet).and_return([test])
       expect(provider.get_without_ethernet).to be
     end
   end
@@ -94,15 +94,15 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     let(:provider) { resource.provider }
 
-    let(:test) { resourcetype.new(@client, {}) }
+    let(:test) { resource_type.new(@client, {}) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
     it 'should be able to get all the network sets without ethernet' do
-      allow(resourcetype).to receive(:get_without_ethernet).and_return([test])
+      allow(resource_type).to receive(:get_without_ethernet).and_return([test])
       expect(provider.get_without_ethernet).to be
     end
   end

--- a/spec/unit/provider/oneview_power_device_c7000_spec.rb
+++ b/spec/unit/provider/oneview_power_device_c7000_spec.rb
@@ -20,7 +20,7 @@ provider_class = Puppet::Type.type(:oneview_power_device).provider(:c7000)
 
 api_version = login[:api_version] || 200
 resource_name = 'PowerDevice'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
@@ -41,10 +41,10 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
     provider.exists?
   end
 
@@ -54,29 +54,29 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to find the resource' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
       expect(provider.found).to be
     end
 
     it 'should not be able to find the resource' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([])
       expect(provider.exists?).not_to be
       expect { provider.found }.to raise_error(/No PowerDevice with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should be able to discover the power device' do
-      allow(resourcetype).to receive(:discover).with(anything, resource['data']).and_return('Test')
+      allow(resource_type).to receive(:discover).with(anything, resource['data']).and_return('Test')
       expect(provider.discover).to be
     end
 
     it 'should get the UID state' do
-      allow_any_instance_of(resourcetype).to receive(:get_uid_state).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_uid_state).and_return('Test')
       expect(provider.get_uid_state).to be
     end
 
     it 'should get the utilization without parameters' do
-      allow_any_instance_of(resourcetype).to receive(:utilization).with({}).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:utilization).with({}).and_return('Test')
       expect(provider.get_utilization).to be
     end
   end
@@ -101,7 +101,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should refresh the power device' do
-      expect_any_instance_of(resourcetype).to receive(:set_refresh_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:set_refresh_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_refresh_state).to be
     end
   end
@@ -123,33 +123,33 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
     it 'should delete the resource' do
       provider.exists?
-      expect_any_instance_of(resourcetype).to receive(:remove).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:remove).and_return(true)
       expect(provider.destroy).to be
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(resourcetype.new(@client, name: resource['data']['name']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add).and_return(resource_type.new(@client, name: resource['data']['name']))
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
 
     it 'should set the uid state' do
       expect(provider.exists?).to eq(true)
-      expect_any_instance_of(resourcetype).to receive(:set_uid_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:set_uid_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_uid_state).to be
     end
 
     it 'should set the power state' do
       expect(provider.exists?).to eq(true)
-      expect_any_instance_of(resourcetype).to receive(:set_power_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:set_power_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_power_state).to be
     end
 
     it 'should be able to retrieve the power connections by name instead of uri' do
       allow(OneviewSDK::FCNetwork).to receive(:find_by).and_return([test])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
-      allow_any_instance_of(resourcetype).to receive(:update).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:add).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:update).and_return(test)
       resource['data']['powerConnections'] = [{ 'name' => 'test', 'type' => 'FCNetwork' }]
       provider.exists?
       expect(provider.create).to be

--- a/spec/unit/provider/oneview_power_device_c7000_spec.rb
+++ b/spec/unit/provider/oneview_power_device_c7000_spec.rb
@@ -17,12 +17,10 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_power_device).provider(:c7000)
+api_version = login[:api_version] || 300
+resource_type = OneviewSDK.resource_named(:PowerDevice, api_version, :C7000)
 
-api_version = login[:api_version] || 200
-resource_name = 'PowerDevice'
-resource_type = Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}") unless api_version < 300
-
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true do
   include_context 'shared context'
 
   let(:resource) do

--- a/spec/unit/provider/oneview_power_device_synergy_spec.rb
+++ b/spec/unit/provider/oneview_power_device_synergy_spec.rb
@@ -17,12 +17,10 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_power_device).provider(:synergy)
+api_version = login[:api_version] || 300
+resource_type = OneviewSDK.resource_named(:PowerDevice, api_version, :Synergy)
 
-api_version = login[:api_version] || 200
-resource_name = 'PowerDevice'
-resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
-
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   let(:resource) do

--- a/spec/unit/provider/oneview_power_device_synergy_spec.rb
+++ b/spec/unit/provider/oneview_power_device_synergy_spec.rb
@@ -20,7 +20,7 @@ provider_class = Puppet::Type.type(:oneview_power_device).provider(:synergy)
 
 api_version = login[:api_version] || 200
 resource_name = 'PowerDevice'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
@@ -41,10 +41,10 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
     provider.exists?
   end
 
@@ -54,33 +54,33 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to find the resource' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
       expect(provider.found).to be
     end
 
     it 'should not be able to find the resource' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([])
       expect(provider.exists?).not_to be
       expect { provider.found }.to raise_error(/No PowerDevice with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should be able to discover the power device' do
-      allow(resourcetype).to receive(:discover).with(anything, resource['data']).and_return('Test')
+      allow(resource_type).to receive(:discover).with(anything, resource['data']).and_return('Test')
       expect(provider.discover).to be
     end
 
     it 'should get the UID state' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:get_uid_state).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_uid_state).and_return('Test')
       expect(provider.get_uid_state).to be
     end
 
     it 'should get the utilization without parameters' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
-      allow_any_instance_of(resourcetype).to receive(:utilization).with({}).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:utilization).with({}).and_return('Test')
       expect(provider.get_utilization).to be
     end
   end
@@ -105,7 +105,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should refresh the power device' do
-      expect_any_instance_of(resourcetype).to receive(:set_refresh_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:set_refresh_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_refresh_state).to be
     end
   end
@@ -127,33 +127,33 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
     it 'should delete the resource' do
       provider.exists?
-      expect_any_instance_of(resourcetype).to receive(:remove).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:remove).and_return(true)
       expect(provider.destroy).to be
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(resourcetype.new(@client, name: resource['data']['name']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add).and_return(resource_type.new(@client, name: resource['data']['name']))
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
 
     it 'should set the uid state' do
       expect(provider.exists?).to eq(true)
-      expect_any_instance_of(resourcetype).to receive(:set_uid_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:set_uid_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_uid_state).to be
     end
 
     it 'should set the power state' do
       expect(provider.exists?).to eq(true)
-      expect_any_instance_of(resourcetype).to receive(:set_power_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      expect_any_instance_of(resource_type).to receive(:set_power_state).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_power_state).to be
     end
 
     it 'should be able to retrieve the power connections by name instead of uri' do
       allow(OneviewSDK::FCNetwork).to receive(:find_by).and_return([test])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
-      allow_any_instance_of(resourcetype).to receive(:update).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:add).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:update).and_return(test)
       resource['data']['powerConnections'] = [{ 'name' => 'test', 'type' => 'FCNetwork' }]
       provider.exists?
       expect(provider.create).to be

--- a/spec/unit/provider/oneview_rack_c7000_spec.rb
+++ b/spec/unit/provider/oneview_rack_c7000_spec.rb
@@ -19,12 +19,12 @@ require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_rack).provider(:c7000)
-resourcetype = OneviewSDK::Rack
+resource_type = OneviewSDK::Rack
 
 describe provider_class, unit: true do
   include_context 'shared context'
 
-  @resourcetype = resourcetype
+  @resource_type = resource_type
   let(:resource) do
     Puppet::Type.type(:oneview_rack).new(
       name: 'rack',
@@ -41,11 +41,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
@@ -59,24 +59,24 @@ describe provider_class, unit: true do
     end
 
     it 'should raise error when server is not found' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([])
       expect { provider.found }.to raise_error(/No Rack with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should be able to add the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(resourcetype.new(@client, resource['data']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add).and_return(resource_type.new(@client, resource['data']))
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
 
     it 'should be able to run through self.instances' do
-      allow(resourcetype).to receive(:get_all).with(anything).and_return([test])
+      allow(resource_type).to receive(:get_all).with(anything).and_return([test])
       expect(instance).to be
     end
 
     it 'should be able to run get_device_topology' do
-      expect_any_instance_of(resourcetype).to receive(:get_device_topology).and_return(['Fake Json'])
+      expect_any_instance_of(resource_type).to receive(:get_device_topology).and_return(['Fake Json'])
       expect(provider.get_device_topology).to be
     end
   end
@@ -97,29 +97,29 @@ describe provider_class, unit: true do
     end
     before(:each) do
       resource['data']['uri'] = '/rest/fake'
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
     it 'should be able to add a rack resource' do
       uri = { 'uri' => resource['data']['rackMounts'][0]['mountUri'] }
       new_res = Hash[resource['data']['rackMounts'][0].to_a]
       new_res.delete('mountUri')
-      expect_any_instance_of(resourcetype).to receive(:add_rack_resource).with(uri, new_res).and_return('test')
-      expect_any_instance_of(resourcetype).to receive(:update).and_return('test')
+      expect_any_instance_of(resource_type).to receive(:add_rack_resource).with(uri, new_res).and_return('test')
+      expect_any_instance_of(resource_type).to receive(:update).and_return('test')
       expect(provider.add_rack_resource).to be
     end
 
     it 'should be able to remove a rack resource' do
       uri = { 'uri' => resource['data']['rackMounts'][0]['mountUri'] }
-      expect_any_instance_of(resourcetype).to receive(:remove_rack_resource).with(uri).and_return('test')
-      expect_any_instance_of(resourcetype).to receive(:update).and_return('test')
+      expect_any_instance_of(resource_type).to receive(:remove_rack_resource).with(uri).and_return('test')
+      expect_any_instance_of(resource_type).to receive(:update).and_return('test')
       expect(provider.remove_rack_resource).to be
     end
 
     it 'should allow specifying a name instead of an uri' do
       resource['data']['rackMounts'][0]['mountUri'] = 'Test, enclosure'
       allow(OneviewSDK::Enclosure).to receive(:find_by).with(anything, name: 'Test').and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
     end
   end
@@ -127,7 +127,7 @@ describe provider_class, unit: true do
   context 'given the minimum parameters' do
     it 'should delete the rack' do
       resource['data']['uri'] = '/rest/fake/'
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.destroy).to be

--- a/spec/unit/provider/oneview_rack_c7000_spec.rb
+++ b/spec/unit/provider/oneview_rack_c7000_spec.rb
@@ -15,16 +15,14 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_rack).provider(:c7000)
-resource_type = OneviewSDK::Rack
+api_version = login[:api_version] || 300
+resource_type = OneviewSDK.resource_named(:Rack, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'
 
-  @resource_type = resource_type
   let(:resource) do
     Puppet::Type.type(:oneview_rack).new(
       name: 'rack',

--- a/spec/unit/provider/oneview_rack_synergy_spec.rb
+++ b/spec/unit/provider/oneview_rack_synergy_spec.rb
@@ -19,12 +19,12 @@ require_relative '../../support/fake_response'
 require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_rack).provider(:synergy)
-resourcetype = OneviewSDK::Rack
+resource_type = OneviewSDK::Rack
 
 describe provider_class, unit: true do
   include_context 'shared context'
 
-  @resourcetype = resourcetype
+  @resource_type = resource_type
   let(:resource) do
     Puppet::Type.type(:oneview_rack).new(
       name: 'rack',
@@ -41,11 +41,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
@@ -59,24 +59,24 @@ describe provider_class, unit: true do
     end
 
     it 'should raise error when server is not found' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([])
       expect { provider.found }.to raise_error(/No Rack with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should be able to add the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(resourcetype.new(@client, resource['data']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add).and_return(resource_type.new(@client, resource['data']))
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
 
     it 'should be able to run through self.instances' do
-      allow(resourcetype).to receive(:get_all).with(anything).and_return([test])
+      allow(resource_type).to receive(:get_all).with(anything).and_return([test])
       expect(instance).to be
     end
 
     it 'should be able to run get_device_topology' do
-      expect_any_instance_of(resourcetype).to receive(:get_device_topology).and_return(['Fake Json'])
+      expect_any_instance_of(resource_type).to receive(:get_device_topology).and_return(['Fake Json'])
       expect(provider.get_device_topology).to be
     end
   end
@@ -97,29 +97,29 @@ describe provider_class, unit: true do
     end
     before(:each) do
       resource['data']['uri'] = '/rest/fake'
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
     it 'should be able to add a rack resource' do
       uri = { 'uri' => resource['data']['rackMounts'][0]['mountUri'] }
       new_res = Hash[resource['data']['rackMounts'][0].to_a]
       new_res.delete('mountUri')
-      expect_any_instance_of(resourcetype).to receive(:add_rack_resource).with(uri, new_res).and_return('test')
-      expect_any_instance_of(resourcetype).to receive(:update).and_return('test')
+      expect_any_instance_of(resource_type).to receive(:add_rack_resource).with(uri, new_res).and_return('test')
+      expect_any_instance_of(resource_type).to receive(:update).and_return('test')
       expect(provider.add_rack_resource).to be
     end
 
     it 'should be able to remove a rack resource' do
       uri = { 'uri' => resource['data']['rackMounts'][0]['mountUri'] }
-      expect_any_instance_of(resourcetype).to receive(:remove_rack_resource).with(uri).and_return('test')
-      expect_any_instance_of(resourcetype).to receive(:update).and_return('test')
+      expect_any_instance_of(resource_type).to receive(:remove_rack_resource).with(uri).and_return('test')
+      expect_any_instance_of(resource_type).to receive(:update).and_return('test')
       expect(provider.remove_rack_resource).to be
     end
 
     it 'should allow specifying a name instead of an uri' do
       resource['data']['rackMounts'][0]['mountUri'] = 'Test, enclosure'
       allow(OneviewSDK::Enclosure).to receive(:find_by).with(anything, name: 'Test').and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
     end
   end
@@ -127,7 +127,7 @@ describe provider_class, unit: true do
   context 'given the minimum parameters' do
     it 'should delete the rack' do
       resource['data']['uri'] = '/rest/fake/'
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.destroy).to be

--- a/spec/unit/provider/oneview_rack_synergy_spec.rb
+++ b/spec/unit/provider/oneview_rack_synergy_spec.rb
@@ -15,16 +15,14 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_rack).provider(:synergy)
-resource_type = OneviewSDK::Rack
+api_version = login[:api_version] || 300
+resource_type = OneviewSDK.resource_named(:Rack, api_version, :Synergy)
 
-describe provider_class, unit: true do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  @resource_type = resource_type
   let(:resource) do
     Puppet::Type.type(:oneview_rack).new(
       name: 'rack',
@@ -92,7 +90,8 @@ describe provider_class, unit: true do
           'rackMounts' => [
             { 'mountUri' => '/rest/enclosures/09SGH100X6J1', 'topUSlot' => 20, 'uHeight' => 10 }
           ]
-        }
+        },
+        provider: 'synergy'
       )
     end
     before(:each) do

--- a/spec/unit/provider/oneview_san_manager_c7000_spec.rb
+++ b/spec/unit/provider/oneview_san_manager_c7000_spec.rb
@@ -21,7 +21,7 @@ provider_class = Puppet::Type.type(:oneview_san_manager).provider(:c7000)
 api_version = login[:api_version] || 200
 resource_type = OneviewSDK.resource_named(:SANManager, api_version, 'C7000')
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true do
   include_context 'shared context'
 
   context 'given the min parameters' do
@@ -97,7 +97,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       end
 
       it 'should update the san manager' do
-        expect(resource_type).to receive(:find_by).and_return([])
+        expect(resource_type).to receive(:find_by).and_return([test])
         expect_any_instance_of(resource_type).to receive(:retrieve!).and_return(true)
         expect_any_instance_of(resource_type).to receive(:like?).and_return(false)
         allow_any_instance_of(resource_type).to receive(:update).and_return(test)

--- a/spec/unit/provider/oneview_san_manager_c7000_spec.rb
+++ b/spec/unit/provider/oneview_san_manager_c7000_spec.rb
@@ -17,9 +17,8 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_san_manager).provider(:c7000)
-
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:SANManager, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:SANManager, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_san_manager_c7000_spec.rb
+++ b/spec/unit/provider/oneview_san_manager_c7000_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:oneview_san_manager).provider(:c7000)
 
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:SANManager, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:SANManager, api_version, 'C7000')
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
@@ -41,14 +41,14 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     it 'should be an instance of the provider C7000' do
       expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_san_manager).provider(:c7000)
     end
 
     it 'should raise error when San Manager is not found' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([])
       provider.exists?
       expect { provider.found }.to raise_error(/No SANManager with the specified data were found on the Oneview Appliance/)
     end
@@ -89,26 +89,26 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       end
 
       it 'should create/add the san manager' do
-        expect(resourcetype).to receive(:find_by).and_return([])
-        expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
-        allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+        expect(resource_type).to receive(:find_by).and_return([])
+        expect_any_instance_of(resource_type).to receive(:retrieve!).and_return(false)
+        allow_any_instance_of(resource_type).to receive(:add).and_return(test)
         provider.exists?
         expect(provider.create).to be
       end
 
       it 'should update the san manager' do
-        expect(resourcetype).to receive(:find_by).and_return([])
-        expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(true)
-        expect_any_instance_of(resourcetype).to receive(:like?).and_return(false)
-        allow_any_instance_of(resourcetype).to receive(:update).and_return(test)
+        expect(resource_type).to receive(:find_by).and_return([])
+        expect_any_instance_of(resource_type).to receive(:retrieve!).and_return(true)
+        expect_any_instance_of(resource_type).to receive(:like?).and_return(false)
+        allow_any_instance_of(resource_type).to receive(:update).and_return(test)
         provider.exists?
         expect(provider.create).to be
       end
 
       it 'should replace provider display name by provider uri' do
         resource['data']['providerUri'] = 'New Name'
-        test = resourcetype.new(@client, resource['data'])
-        expect(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+        test = resource_type.new(@client, resource['data'])
+        expect(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
         provider.exists?
       end
     end
@@ -116,14 +116,14 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     context 'given the minimum parameters after San Manager creation' do
       before(:each) do
         resource['data']['uri'] = '/rest/san-managers/fake'
-        test = resourcetype.new(@client, resource['data'])
-        allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-        allow(resourcetype).to receive(:get_all).with(anything).and_return([test])
+        test = resource_type.new(@client, resource['data'])
+        allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+        allow(resource_type).to receive(:get_all).with(anything).and_return([test])
         provider.exists?
       end
 
       it 'should be able to run through self.instances' do
-        allow_any_instance_of(resourcetype).to receive(:find_by)
+        allow_any_instance_of(resource_type).to receive(:find_by)
         expect(instance).to be
       end
 

--- a/spec/unit/provider/oneview_san_manager_c7000_spec.rb
+++ b/spec/unit/provider/oneview_san_manager_c7000_spec.rb
@@ -19,8 +19,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:oneview_san_manager).provider(:c7000)
 
 api_version = login[:api_version] || 200
-resource_name = 'SANManager'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}") unless api_version < 300
+resourcetype = OneviewSDK.resource_named(:SANManager, api_version, 'C7000')
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
@@ -90,18 +89,18 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       end
 
       it 'should create/add the san manager' do
-        expect(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
-        expect(resourcetype).to receive(:find_by).with(anything, 'providerDisplayName' => resource['data']['providerDisplayName'])
-          .and_return([])
-        provider.exists?
+        expect(resourcetype).to receive(:find_by).and_return([])
+        expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
         allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+        provider.exists?
         expect(provider.create).to be
       end
 
       it 'should update the san manager' do
-        expect(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
-        expect(resourcetype).to receive(:find_by).with(anything, 'providerDisplayName' => resource['data']['providerDisplayName'])
-          .and_return([test])
+        expect(resourcetype).to receive(:find_by).and_return([])
+        expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(true)
+        expect_any_instance_of(resourcetype).to receive(:like?).and_return(false)
+        allow_any_instance_of(resourcetype).to receive(:update).and_return(test)
         provider.exists?
         expect(provider.create).to be
       end

--- a/spec/unit/provider/oneview_san_manager_synergy_spec.rb
+++ b/spec/unit/provider/oneview_san_manager_synergy_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:oneview_san_manager).provider(:synergy)
 
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:SANManager, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:SANManager, api_version, 'Synergy')
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
@@ -41,14 +41,14 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     it 'should be an instance of the provider Synergy' do
       expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_san_manager).provider(:synergy)
     end
 
     it 'should raise error when San Manager is not found' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([])
       provider.exists?
       expect { provider.found }.to raise_error(/No SANManager with the specified data were found on the Oneview Appliance/)
     end
@@ -89,26 +89,26 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       end
 
       it 'should create/add the san manager' do
-        expect(resourcetype).to receive(:find_by).and_return([])
-        expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
-        allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+        expect(resource_type).to receive(:find_by).and_return([])
+        expect_any_instance_of(resource_type).to receive(:retrieve!).and_return(false)
+        allow_any_instance_of(resource_type).to receive(:add).and_return(test)
         provider.exists?
         expect(provider.create).to be
       end
 
       it 'should update the san manager' do
-        expect(resourcetype).to receive(:find_by).and_return([])
-        expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(true)
-        expect_any_instance_of(resourcetype).to receive(:like?).and_return(false)
-        allow_any_instance_of(resourcetype).to receive(:update).and_return(test)
+        expect(resource_type).to receive(:find_by).and_return([])
+        expect_any_instance_of(resource_type).to receive(:retrieve!).and_return(true)
+        expect_any_instance_of(resource_type).to receive(:like?).and_return(false)
+        allow_any_instance_of(resource_type).to receive(:update).and_return(test)
         provider.exists?
         expect(provider.create).to be
       end
 
       it 'should replace provider display name by provider uri' do
         resource['data']['providerUri'] = 'New Name'
-        test = resourcetype.new(@client, resource['data'])
-        expect(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+        test = resource_type.new(@client, resource['data'])
+        expect(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
         provider.exists?
       end
     end
@@ -116,14 +116,14 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     context 'given the minimum parameters after San Manager creation' do
       before(:each) do
         resource['data']['uri'] = '/rest/san-managers/fake'
-        test = resourcetype.new(@client, resource['data'])
-        allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-        allow(resourcetype).to receive(:get_all).with(anything).and_return([test])
+        test = resource_type.new(@client, resource['data'])
+        allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+        allow(resource_type).to receive(:get_all).with(anything).and_return([test])
         provider.exists?
       end
 
       it 'should be able to run through self.instances' do
-        allow_any_instance_of(resourcetype).to receive(:find_by)
+        allow_any_instance_of(resource_type).to receive(:find_by)
         expect(instance).to be
       end
 

--- a/spec/unit/provider/oneview_san_manager_synergy_spec.rb
+++ b/spec/unit/provider/oneview_san_manager_synergy_spec.rb
@@ -97,7 +97,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       end
 
       it 'should update the san manager' do
-        expect(resource_type).to receive(:find_by).and_return([])
+        expect(resource_type).to receive(:find_by).and_return([test])
         expect_any_instance_of(resource_type).to receive(:retrieve!).and_return(true)
         expect_any_instance_of(resource_type).to receive(:like?).and_return(false)
         allow_any_instance_of(resource_type).to receive(:update).and_return(test)

--- a/spec/unit/provider/oneview_san_manager_synergy_spec.rb
+++ b/spec/unit/provider/oneview_san_manager_synergy_spec.rb
@@ -17,11 +17,10 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_san_manager).provider(:synergy)
-
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:SANManager, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:SANManager, api_version, :Synergy)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   context 'given the min parameters' do

--- a/spec/unit/provider/oneview_sas_interconnect_spec.rb
+++ b/spec/unit/provider/oneview_sas_interconnect_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_sas_interconnect).provider(:synergy)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:SASInterconnect, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:SASInterconnect, api_version, 'Synergy')
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
@@ -46,11 +46,11 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
-    allow_any_instance_of(resourcetype).to receive(:patch).and_return(test)
+    allow(resource_type).to receive(:find_by).and_return([test])
+    allow_any_instance_of(resource_type).to receive(:patch).and_return(test)
     provider.exists?
   end
 
@@ -73,12 +73,12 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to get a specific type' do
-      allow(resourcetype).to receive(:get_type).and_return(['fake_type'])
+      allow(resource_type).to receive(:get_type).and_return(['fake_type'])
       expect(provider.get_types).to be
     end
 
     it 'should be able to set a refresh state' do
-      allow_any_instance_of(resourcetype).to receive(:set_refresh_state).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:set_refresh_state).and_return(true)
       expect(provider.set_refresh_state).to be
     end
   end
@@ -93,7 +93,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       )
     end
     it 'should be able to get all types' do
-      allow(resourcetype).to receive(:get_types).and_return(['fake_type1'])
+      allow(resource_type).to receive(:get_types).and_return(['fake_type1'])
       provider.exists?
       expect(provider.get_types).to be
     end

--- a/spec/unit/provider/oneview_sas_interconnect_spec.rb
+++ b/spec/unit/provider/oneview_sas_interconnect_spec.rb
@@ -17,10 +17,10 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_sas_interconnect).provider(:synergy)
-api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:SASInterconnect, api_version, 'Synergy')
+api_version = login[:api_version] || 300
+resource_type = OneviewSDK.resource_named(:SASInterconnect, api_version, :Synergy)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   let(:resource) do

--- a/spec/unit/provider/oneview_sas_logical_interconnect_group_spec.rb
+++ b/spec/unit/provider/oneview_sas_logical_interconnect_group_spec.rb
@@ -18,10 +18,9 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_sas_logical_interconnect_group).provider(:synergy)
 api_version = login[:api_version] || 300
-resource_name = 'SASLogicalInterconnectGroup'
-resource_type ||= Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless login[:api_version] == 200
+resource_type = OneviewSDK.resource_named(:SASLogicalInterconnectGroup, api_version, :Synergy)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   let(:resource) do

--- a/spec/unit/provider/oneview_sas_logical_interconnect_group_spec.rb
+++ b/spec/unit/provider/oneview_sas_logical_interconnect_group_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:oneview_sas_logical_interconnect_group).provider(:synergy)
 api_version = login[:api_version] || 300
 resource_name = 'SASLogicalInterconnectGroup'
-resourcetype ||= Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless login[:api_version] == 200
+resource_type ||= Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless login[:api_version] == 200
 
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
@@ -51,11 +51,11 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the min parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -68,9 +68,9 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add_interconnect).and_return('')
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add_interconnect).and_return('')
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       expect(provider.create).to be
     end
 
@@ -79,7 +79,7 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'deletes the resource' do
-      expect_any_instance_of(resourcetype).to receive(:delete).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:delete).and_return(true)
       expect(provider.destroy).to be
     end
   end

--- a/spec/unit/provider/oneview_sas_logical_interconnect_spec.rb
+++ b/spec/unit/provider/oneview_sas_logical_interconnect_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:SASLogicalInterconnect, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:SASLogicalInterconnect, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_sas_logical_interconnect).new(
@@ -49,11 +49,11 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the min parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -75,17 +75,17 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should be able to get the firmware' do
-      allow_any_instance_of(resourcetype).to receive(:get_firmware).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_firmware).and_return('Test')
       expect(provider.get_firmware).to be
     end
 
     it 'should be able to set the compliance' do
-      allow_any_instance_of(resourcetype).to receive(:compliance).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      allow_any_instance_of(resource_type).to receive(:compliance).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_compliance).to be
     end
 
     it 'should be able to set the configuration' do
-      allow_any_instance_of(resourcetype).to receive(:configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      allow_any_instance_of(resource_type).to receive(:configuration).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.set_configuration).to be
     end
 
@@ -93,12 +93,12 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       allow(OneviewSDK::FirmwareDriver).to receive(:find_by).and_return(
         [OneviewSDK::FirmwareDriver.new(@client, name: 'test')]
       )
-      allow_any_instance_of(resourcetype).to receive(:firmware_update).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:firmware_update).and_return(true)
       expect(provider.set_firmware).to be
     end
 
     it 'should be able to update the drive serial numbers after replacement' do
-      allow_any_instance_of(resourcetype).to receive(:replace_drive_enclosure).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      allow_any_instance_of(resource_type).to receive(:replace_drive_enclosure).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.replace_drive_enclosure).to be
     end
   end

--- a/spec/unit/provider/oneview_sas_logical_interconnect_spec.rb
+++ b/spec/unit/provider/oneview_sas_logical_interconnect_spec.rb
@@ -17,12 +17,11 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_sas_logical_interconnect).provider(:synergy)
-api_version = login[:api_version] || 200
+api_version = login[:api_version] || 300
+resource_type = OneviewSDK.resource_named(:SASLogicalInterconnect, api_version, :Synergy)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:SASLogicalInterconnect, api_version, 'Synergy')
 
   let(:resource) do
     Puppet::Type.type(:oneview_sas_logical_interconnect).new(

--- a/spec/unit/provider/oneview_server_hardware_c7000_spec.rb
+++ b/spec/unit/provider/oneview_server_hardware_c7000_spec.rb
@@ -19,16 +19,16 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:oneview_server_hardware).provider(:c7000)
 api_version = login[:api_version] || 200
 resource_name = 'ServerHardware'
-resourcetype = if api_version == 200
-                 Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-               else
-                 Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-               end
+resource_type = if api_version == 200
+                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
+                else
+                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
+                end
 
 describe provider_class, unit: true do
   include_context 'shared context'
 
-  @resourcetype = resourcetype
+  @resource_type = resource_type
   let(:resource) do
     Puppet::Type.type(:oneview_server_hardware).new(
       name: 'server_hardware',
@@ -45,11 +45,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
-    allow(resourcetype).to receive(:get_all).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:get_all).and_return([test])
     provider.exists?
   end
 
@@ -59,7 +59,7 @@ describe provider_class, unit: true do
     end
 
     it 'should raise error when server is not found' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect { provider.found }.to raise_error(/No ServerHardware with the specified data were found on the Oneview Appliance/)
     end
   end
@@ -84,8 +84,8 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(resourcetype.new(@client, resource['data']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add).and_return(resource_type.new(@client, resource['data']))
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
@@ -94,8 +94,8 @@ describe provider_class, unit: true do
   context 'given the minimum parameters after server creation' do
     before(:each) do
       resource['data']['uri'] = '/rest/server-hardware/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new('Fake Get Statistics'))
       path = 'spec/support/fixtures/unit/provider/server_hardware.json'
       fake_json_response = File.read(path)
@@ -131,8 +131,8 @@ describe provider_class, unit: true do
   context 'given the minimum parameters for the SET methods' do
     before(:each) do
       resource['data']['uri'] = '/rest/server-hardware/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       path = 'spec/support/fixtures/unit/provider/server_hardware.json'
       fake_json_response = File.read(path)
       allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return(fake_json_response)
@@ -155,13 +155,13 @@ describe provider_class, unit: true do
 
     it 'should set the power state to on' do
       resource['data']['power_state'] = 'On'
-      allow_any_instance_of(resourcetype).to receive(:power_on).with(false).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:power_on).with(false).and_return('Test')
       expect(provider.set_power_state).to be
     end
 
     it 'should set the power state to off' do
       resource['data']['power_state'] = 'Off'
-      allow_any_instance_of(resourcetype).to receive(:power_off).with(false).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:power_off).with(false).and_return('Test')
       expect(provider.set_power_state).to be
     end
 
@@ -171,7 +171,7 @@ describe provider_class, unit: true do
 
     it 'should be able to set a refresh state' do
       resource['data']['state'] = 'RefreshPending'
-      allow_any_instance_of(resourcetype).to receive(:set_refresh_state).with('RefreshPending', {}).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:set_refresh_state).with('RefreshPending', {}).and_return('Test')
       expect(provider.set_refresh_state).to be
     end
 
@@ -197,7 +197,7 @@ describe provider_class, unit: true do
       )
     end
     it '#patch should be able to run patch operations' do
-      allow_any_instance_of(resourcetype).to receive(:patch).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:patch).and_return(test)
       expect(provider.create).to be
     end
   end

--- a/spec/unit/provider/oneview_server_hardware_c7000_spec.rb
+++ b/spec/unit/provider/oneview_server_hardware_c7000_spec.rb
@@ -18,17 +18,11 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_hardware).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_name = 'ServerHardware'
-resource_type = if api_version == 200
-                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-                else
-                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-                end
+resource_type = OneviewSDK.resource_named(:ServerHardware, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'
 
-  @resource_type = resource_type
   let(:resource) do
     Puppet::Type.type(:oneview_server_hardware).new(
       name: 'server_hardware',

--- a/spec/unit/provider/oneview_server_hardware_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_hardware_synergy_spec.rb
@@ -18,8 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_hardware).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_name = 'ServerHardware'
-resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = OneviewSDK.resource_named(:ServerHardware, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_server_hardware_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_hardware_synergy_spec.rb
@@ -19,12 +19,12 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:oneview_server_hardware).provider(:synergy)
 api_version = login[:api_version] || 200
 resource_name = 'ServerHardware'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  @resourcetype = resourcetype
+  @resource_type = resource_type
   let(:resource) do
     Puppet::Type.type(:oneview_server_hardware).new(
       name: 'server_hardware',
@@ -41,11 +41,11 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
-    allow(resourcetype).to receive(:get_all).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:get_all).and_return([test])
     provider.exists?
   end
 
@@ -55,7 +55,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should raise error when server is not found' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect { provider.found }.to raise_error(/No ServerHardware with the specified data were found on the Oneview Appliance/)
     end
   end
@@ -80,8 +80,8 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(resourcetype.new(@client, resource['data']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add).and_return(resource_type.new(@client, resource['data']))
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
@@ -90,8 +90,8 @@ describe provider_class, unit: true, if: api_version >= 300 do
   context 'given the minimum parameters after server creation' do
     before(:each) do
       resource['data']['uri'] = '/rest/server-hardware/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new('Fake Get Statistics'))
       path = 'spec/support/fixtures/unit/provider/server_hardware.json'
       fake_json_response = File.read(path)
@@ -127,8 +127,8 @@ describe provider_class, unit: true, if: api_version >= 300 do
   context 'given the minimum parameters for the SET methods' do
     before(:each) do
       resource['data']['uri'] = '/rest/server-hardware/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       path = 'spec/support/fixtures/unit/provider/server_hardware.json'
       fake_json_response = File.read(path)
       allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return(fake_json_response)
@@ -151,13 +151,13 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     it 'should set the power state to on' do
       resource['data']['power_state'] = 'On'
-      allow_any_instance_of(resourcetype).to receive(:power_on).with(false).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:power_on).with(false).and_return('Test')
       expect(provider.set_power_state).to be
     end
 
     it 'should set the power state to off' do
       resource['data']['power_state'] = 'Off'
-      allow_any_instance_of(resourcetype).to receive(:power_off).with(false).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:power_off).with(false).and_return('Test')
       expect(provider.set_power_state).to be
     end
 
@@ -167,7 +167,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     it 'should be able to set a refresh state' do
       resource['data']['state'] = 'RefreshPending'
-      allow_any_instance_of(resourcetype).to receive(:set_refresh_state).with('RefreshPending', {}).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:set_refresh_state).with('RefreshPending', {}).and_return('Test')
       expect(provider.set_refresh_state).to be
     end
 
@@ -193,7 +193,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
       )
     end
     it '#patch should be able to run patch operations' do
-      allow_any_instance_of(resourcetype).to receive(:patch).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:patch).and_return(test)
       expect(provider.create).to be
     end
   end

--- a/spec/unit/provider/oneview_server_hardware_type_c7000_spec.rb
+++ b/spec/unit/provider/oneview_server_hardware_type_c7000_spec.rb
@@ -17,7 +17,7 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_hardware_type).provider(:c7000)
-resourcetype = OneviewSDK::ServerHardwareType
+resource_type = OneviewSDK::ServerHardwareType
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -38,12 +38,12 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters before server creation' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
-      allow(resourcetype).to receive(:get_all).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:get_all).and_return([test])
       provider.exists?
     end
 
@@ -56,19 +56,19 @@ describe provider_class, unit: true do
     end
 
     it 'should raise error when server is not found' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       provider.exists?
       expect { provider.found }.to raise_error(/No ServerHardwareType with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should be able to update the resource name, and change it back' do
-      allow_any_instance_of(resourcetype).to receive(:update).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:update).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should delete the server hardware' do
-      expect_any_instance_of(resourcetype).to receive(:remove).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:remove).and_return(true)
       provider.exists?
       expect(provider.destroy).to be
     end

--- a/spec/unit/provider/oneview_server_hardware_type_c7000_spec.rb
+++ b/spec/unit/provider/oneview_server_hardware_type_c7000_spec.rb
@@ -17,7 +17,8 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_hardware_type).provider(:c7000)
-resource_type = OneviewSDK::ServerHardwareType
+api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:ServerHardwareType, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_server_hardware_type_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_hardware_type_synergy_spec.rb
@@ -17,7 +17,7 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_hardware_type).provider(:synergy)
-resourcetype = OneviewSDK::ServerHardwareType
+resource_type = OneviewSDK::ServerHardwareType
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -38,12 +38,12 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters before server creation' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
-      allow(resourcetype).to receive(:get_all).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:get_all).and_return([test])
       provider.exists?
     end
 
@@ -57,19 +57,19 @@ describe provider_class, unit: true do
     end
 
     it 'should raise error when server is not found' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       provider.exists?
       expect { provider.found }.to raise_error(/No ServerHardwareType with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should be able to update the resource name, and change it back' do
-      allow_any_instance_of(resourcetype).to receive(:update).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:update).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should delete the server hardware' do
-      expect_any_instance_of(resourcetype).to receive(:remove).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:remove).and_return(true)
       provider.exists?
       expect(provider.destroy).to be
     end

--- a/spec/unit/provider/oneview_server_hardware_type_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_hardware_type_synergy_spec.rb
@@ -17,7 +17,8 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_hardware_type).provider(:synergy)
-resource_type = OneviewSDK::ServerHardwareType
+api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:ServerHardwareType, api_version, :Synergy)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_server_profile_c7000_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_c7000_spec.rb
@@ -16,10 +16,9 @@
 
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:oneview_server_profile).provider(:oneview_server_profile)
+provider_class = Puppet::Type.type(:oneview_server_profile).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:ServerProfile, api_version, 'C7000')
-
+resource_type = OneviewSDK.resource_named(:ServerProfile, api_version, :C7000)
 fake_json_response = File.read('spec/support/fixtures/unit/provider/server_profile.json')
 
 describe provider_class, unit: true do

--- a/spec/unit/provider/oneview_server_profile_c7000_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_profile).provider(:oneview_server_profile)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:ServerProfile, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:ServerProfile, api_version, 'C7000')
 
 fake_json_response = File.read('spec/support/fixtures/unit/provider/server_profile.json')
 
@@ -43,13 +43,12 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
-    allow_any_instance_of(resourcetype).to receive(:exists?).and_return(true)
-    allow_any_instance_of(resourcetype).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(resourcetype).to receive(:like?).and_return(true)
+    allow(resource_type).to receive(:find_by).and_return([test])
+    allow_any_instance_of(resource_type).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(resource_type).to receive(:like?).and_return(true)
     provider.exists?
   end
 
@@ -59,75 +58,73 @@ describe provider_class, unit: true do
     end
 
     it 'should raise error when server is not found' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect { provider.found }.to raise_error(/No ServerProfile with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should create when resource does not exist' do
-      allow_any_instance_of(resourcetype).to receive(:exists?).and_return(false)
-      allow_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:retrieve!).and_return(false)
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
 
     it 'should not create when resource is compliant' do
       expect(provider.exists?).to eq(true)
-      expect(resourcetype).not_to receive(:create)
+      expect(resource_type).not_to receive(:create)
       expect(provider.create).to be
     end
 
     it 'should update when resource is not compliant' do
-      allow_any_instance_of(resourcetype).to receive(:exists?).and_return(true)
-      allow_any_instance_of(resourcetype).to receive(:retrieve!).and_return(true)
-      allow_any_instance_of(resourcetype).to receive(:like?).and_return(false)
-      expect_any_instance_of(resourcetype).to receive(:update).and_return(true)
-      expect_any_instance_of(resourcetype).not_to receive(:create)
+      allow_any_instance_of(resource_type).to receive(:retrieve!).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:like?).and_return(false)
+      expect_any_instance_of(resource_type).to receive(:update).and_return(true)
+      expect_any_instance_of(resource_type).not_to receive(:create)
       expect(provider.create).to be
     end
 
     it 'should be able to perform the patch update' do
-      allow_any_instance_of(resourcetype).to receive(:update_from_template).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      allow_any_instance_of(resource_type).to receive(:update_from_template).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.update_from_template).to be
     end
 
     it 'should be able to get available targets' do
-      allow(resourcetype).to receive(:get_available_targets).with(anything, nil).and_return(fake_json_response)
+      allow(resource_type).to receive(:get_available_targets).with(anything, nil).and_return(fake_json_response)
       expect(provider.get_available_targets).to be
     end
 
     it 'should be able to get the compliance preview' do
-      allow_any_instance_of(resourcetype).to receive(:get_compliance_preview).and_return(fake_json_response)
+      allow_any_instance_of(resource_type).to receive(:get_compliance_preview).and_return(fake_json_response)
       expect(provider.get_compliance_preview).to be
     end
 
     it 'should be able to get available networks' do
-      allow_any_instance_of(resourcetype).to receive(:get_available_networks).and_return(fake_json_response)
+      allow_any_instance_of(resource_type).to receive(:get_available_networks).and_return(fake_json_response)
       expect(provider.get_available_networks).to be
     end
 
     it 'should be able to get the transformation' do
-      allow_any_instance_of(resourcetype).to receive(:get_transformation).and_return(fake_json_response)
+      allow_any_instance_of(resource_type).to receive(:get_transformation).and_return(fake_json_response)
       expect(provider.get_transformation).to be
     end
 
     it 'should be able to get messages' do
-      allow_any_instance_of(resourcetype).to receive(:get_messages).and_return(fake_json_response)
+      allow_any_instance_of(resource_type).to receive(:get_messages).and_return(fake_json_response)
       expect(provider.get_messages).to be
     end
 
     it 'should be able to get available servers' do
-      allow(resourcetype).to receive(:get_available_servers).and_return(fake_json_response)
+      allow(resource_type).to receive(:get_available_servers).and_return(fake_json_response)
       expect(provider.get_available_servers).to be
     end
 
     it 'should be able to get profile ports' do
-      allow(resourcetype).to receive(:get_profile_ports).and_return(fake_json_response)
+      allow(resource_type).to receive(:get_profile_ports).and_return(fake_json_response)
       expect(provider.get_profile_ports).to be
     end
 
     it 'should delete the server profile' do
-      expect_any_instance_of(resourcetype).to receive(:delete).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:delete).and_return(true)
       expect(provider.destroy).to be
     end
 
@@ -157,17 +154,17 @@ describe provider_class, unit: true do
     end
 
     it 'should successfully get an available storage system' do
-      allow(resourcetype).to receive(:get_available_storage_system).and_return(true)
+      allow(resource_type).to receive(:get_available_storage_system).and_return(true)
       expect(provider.get_available_storage_system).to be
     end
 
     it 'should successfully get_available_storage_systems' do
-      allow(resourcetype).to receive(:get_available_storage_systems).and_return(true)
+      allow(resource_type).to receive(:get_available_storage_systems).and_return(true)
       expect(provider.get_available_storage_systems).to be
     end
 
     it 'should successfully get_available_networks' do
-      allow(resourcetype).to receive(:get_available_networks).and_return(true)
+      allow(resource_type).to receive(:get_available_networks).and_return(true)
       provider.exists?
       expect(provider.get_available_networks).to be
     end

--- a/spec/unit/provider/oneview_server_profile_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_synergy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_profile).provider(:oneview_server_profile)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:ServerProfile, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:ServerProfile, api_version, :Synergy)
 fake_json_response = File.read('spec/support/fixtures/unit/provider/server_profile.json')
 
 describe provider_class, unit: true, if: api_version >= 300 do

--- a/spec/unit/provider/oneview_server_profile_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_synergy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_profile).provider(:oneview_server_profile)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:ServerProfile, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:ServerProfile, api_version, 'Synergy')
 fake_json_response = File.read('spec/support/fixtures/unit/provider/server_profile.json')
 
 describe provider_class, unit: true, if: api_version >= 300 do
@@ -42,13 +42,12 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
-    allow_any_instance_of(resourcetype).to receive(:exists?).and_return(true)
-    allow_any_instance_of(resourcetype).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(resourcetype).to receive(:like?).and_return(true)
+    allow(resource_type).to receive(:find_by).and_return([test])
+    allow_any_instance_of(resource_type).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(resource_type).to receive(:like?).and_return(true)
     provider.exists?
   end
 
@@ -58,90 +57,88 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should raise error when server is not found' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect { provider.found }.to raise_error(/No ServerProfile with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should create when resource does not exist' do
-      allow_any_instance_of(resourcetype).to receive(:exists?).and_return(false)
-      allow_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:retrieve!).and_return(false)
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
 
     it 'should not create when resource is compliant' do
       expect(provider.exists?).to eq(true)
-      expect(resourcetype).not_to receive(:create)
+      expect(resource_type).not_to receive(:create)
       expect(provider.create).to be
     end
 
     it 'should update when resource is not compliant' do
-      allow_any_instance_of(resourcetype).to receive(:exists?).and_return(true)
-      allow_any_instance_of(resourcetype).to receive(:retrieve!).and_return(true)
-      allow_any_instance_of(resourcetype).to receive(:like?).and_return(false)
-      expect_any_instance_of(resourcetype).to receive(:update).and_return(true)
-      expect_any_instance_of(resourcetype).not_to receive(:create)
+      allow_any_instance_of(resource_type).to receive(:retrieve!).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:like?).and_return(false)
+      expect_any_instance_of(resource_type).to receive(:update).and_return(true)
+      expect_any_instance_of(resource_type).not_to receive(:create)
       expect(provider.create).to be
     end
 
     it 'should be able to perform the patch update' do
-      allow_any_instance_of(resourcetype).to receive(:update_from_template).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      allow_any_instance_of(resource_type).to receive(:update_from_template).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.update_from_template).to be
     end
 
     it 'should be able to get available targets' do
-      allow(resourcetype).to receive(:get_available_targets).with(anything, nil).and_return(fake_json_response)
+      allow(resource_type).to receive(:get_available_targets).with(anything, nil).and_return(fake_json_response)
       expect(provider.get_available_targets).to be
     end
 
     it 'should be able to get the compliance preview' do
-      allow_any_instance_of(resourcetype).to receive(:get_compliance_preview).and_return(fake_json_response)
+      allow_any_instance_of(resource_type).to receive(:get_compliance_preview).and_return(fake_json_response)
       expect(provider.get_compliance_preview).to be
     end
 
     it 'should be able to get available networks' do
-      allow_any_instance_of(resourcetype).to receive(:get_available_networks).and_return(fake_json_response)
+      allow_any_instance_of(resource_type).to receive(:get_available_networks).and_return(fake_json_response)
       expect(provider.get_available_networks).to be
     end
 
     it 'should be able to get the transformation' do
-      allow_any_instance_of(resourcetype).to receive(:get_transformation).and_return(fake_json_response)
+      allow_any_instance_of(resource_type).to receive(:get_transformation).and_return(fake_json_response)
       expect(provider.get_transformation).to be
     end
 
     it 'should be able to get messages' do
-      allow_any_instance_of(resourcetype).to receive(:get_messages).and_return(fake_json_response)
+      allow_any_instance_of(resource_type).to receive(:get_messages).and_return(fake_json_response)
       expect(provider.get_messages).to be
     end
 
     it 'should be able to get available servers' do
-      allow(resourcetype).to receive(:get_available_servers).and_return(fake_json_response)
+      allow(resource_type).to receive(:get_available_servers).and_return(fake_json_response)
       expect(provider.get_available_servers).to be
     end
 
     it 'should be able to get profile ports' do
-      allow(resourcetype).to receive(:get_profile_ports).and_return(fake_json_response)
+      allow(resource_type).to receive(:get_profile_ports).and_return(fake_json_response)
       expect(provider.get_profile_ports).to be
     end
 
     it 'should delete the server profile' do
-      expect_any_instance_of(resourcetype).to receive(:delete).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:delete).and_return(true)
       expect(provider.destroy).to be
     end
 
     it 'should be able to get a sas logical jbod by name' do
-      allow(resourcetype).to receive(:get_sas_logical_jbod).and_return(true)
+      allow(resource_type).to receive(:get_sas_logical_jbod).and_return(true)
       expect(provider.get_sas_logical_jbods).to be
     end
 
     it 'should be able to get_sas_logical_jbod_drives for a server profile' do
-      allow(resourcetype).to receive(:get_sas_logical_jbod_drives).and_return(true)
+      allow(resource_type).to receive(:get_sas_logical_jbod_drives).and_return(true)
       expect(provider.get_sas_logical_jbod_drives).to be
     end
 
     it 'should be able to get a sas logical jbod attachment by name' do
-      allow(resourcetype).to receive(:get_sas_logical_jbod_attachment).and_return(true)
+      allow(resource_type).to receive(:get_sas_logical_jbod_attachment).and_return(true)
       expect(provider.get_sas_logical_jbod_attachments).to be
     end
   end
@@ -165,28 +162,28 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should successfully get an available storage system' do
-      allow(resourcetype).to receive(:get_available_storage_system).and_return(true)
+      allow(resource_type).to receive(:get_available_storage_system).and_return(true)
       expect(provider.get_available_storage_system).to be
     end
 
     it 'should successfully get_available_storage_systems' do
-      allow(resourcetype).to receive(:get_available_storage_systems).and_return(true)
+      allow(resource_type).to receive(:get_available_storage_systems).and_return(true)
       expect(provider.get_available_storage_systems).to be
     end
 
     it 'should successfully get_available_networks' do
-      allow(resourcetype).to receive(:get_available_networks).and_return(true)
+      allow(resource_type).to receive(:get_available_networks).and_return(true)
       provider.exists?
       expect(provider.get_available_networks).to be
     end
 
     it 'should be able to get all sas logical jbod' do
-      allow(resourcetype).to receive(:get_sas_logical_jbods).and_return(true)
+      allow(resource_type).to receive(:get_sas_logical_jbods).and_return(true)
       expect(provider.get_sas_logical_jbods).to be
     end
 
     it 'should be able to get all sas logical jbod attachment' do
-      allow(resourcetype).to receive(:get_sas_logical_jbod_attachments).and_return(true)
+      allow(resource_type).to receive(:get_sas_logical_jbod_attachments).and_return(true)
       expect(provider.get_sas_logical_jbod_attachments).to be
     end
   end

--- a/spec/unit/provider/oneview_server_profile_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_synergy_spec.rb
@@ -21,7 +21,7 @@ api_version = login[:api_version] || 200
 resourcetype = OneviewSDK.resource_named(:ServerProfile, api_version, 'Synergy')
 fake_json_response = File.read('spec/support/fixtures/unit/provider/server_profile.json')
 
-describe provider_class, unit: true do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   let(:resource) do

--- a/spec/unit/provider/oneview_server_profile_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_synergy_spec.rb
@@ -17,13 +17,11 @@
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_profile).provider(:oneview_server_profile)
+api_version = login[:api_version] || 200
+resourcetype = OneviewSDK.resource_named(:ServerProfile, api_version, 'Synergy')
+fake_json_response = File.read('spec/support/fixtures/unit/provider/server_profile.json')
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
-  api_version = login[:api_version] || 200
-  resource_name = 'ServerProfile'
-  resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
-  fake_json_response = File.read('spec/support/fixtures/unit/provider/server_profile.json')
-
+describe provider_class, unit: true do
   include_context 'shared context'
 
   let(:resource) do
@@ -48,6 +46,9 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   before(:each) do
     allow(resourcetype).to receive(:find_by).and_return([test])
+    allow_any_instance_of(resourcetype).to receive(:exists?).and_return(true)
+    allow_any_instance_of(resourcetype).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(resourcetype).to receive(:like?).and_return(true)
     provider.exists?
   end
 
@@ -61,17 +62,11 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
       expect { provider.found }.to raise_error(/No ServerProfile with the specified data were found on the Oneview Appliance/)
     end
 
-    it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+    it 'should create when resource does not exist' do
+      allow_any_instance_of(resourcetype).to receive(:exists?).and_return(false)
+      allow_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
       allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
       expect(provider.exists?).to eq(false)
-      expect(provider.create).to be
-    end
-
-    it 'should create when resource does not exist' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      expect(provider.exists?).to eq(false)
-      expect_any_instance_of(resourcetype).to receive(:create).and_return(test)
       expect(provider.create).to be
     end
 
@@ -82,8 +77,10 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'should update when resource is not compliant' do
-      test['description'] = 'new description'
-      expect_any_instance_of(resourcetype).to receive(:update)
+      allow_any_instance_of(resourcetype).to receive(:exists?).and_return(true)
+      allow_any_instance_of(resourcetype).to receive(:retrieve!).and_return(true)
+      allow_any_instance_of(resourcetype).to receive(:like?).and_return(false)
+      expect_any_instance_of(resourcetype).to receive(:update).and_return(true)
       expect_any_instance_of(resourcetype).not_to receive(:create)
       expect(provider.create).to be
     end

--- a/spec/unit/provider/oneview_server_profile_template_c7000_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_template_c7000_spec.rb
@@ -15,17 +15,10 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_server_profile_template).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_name = 'ServerProfileTemplate'
-resourcetype = if api_version == 200
-                 Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-               else
-                 Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-               end
+resourcetype = OneviewSDK.resource_named(:ServerProfileTemplate, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_server_profile_template_c7000_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_template_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_profile_template).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:ServerProfileTemplate, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:ServerProfileTemplate, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -43,10 +43,10 @@ describe provider_class, unit: true do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -55,7 +55,7 @@ describe provider_class, unit: true do
     end
 
     it 'should run exists? and return the resource does not exist' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
@@ -68,36 +68,36 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(resourcetype.new(@client, resource['data']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(resource_type.new(@client, resource['data']))
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
 
     it 'should create when resource does not exist' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
-      expect_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      expect_any_instance_of(resource_type).to receive(:create).and_return(test)
       expect(provider.create).to be
     end
 
     it 'should not create when resource is compliant' do
       expect(provider.exists?).to eq(true)
-      expect(resourcetype).not_to receive(:create)
+      expect(resource_type).not_to receive(:create)
       expect(provider.create).to be
     end
 
     it 'should update when resource is not compliant' do
       test['description'] = 'new description'
-      expect_any_instance_of(resourcetype).to receive(:update)
-      expect_any_instance_of(resourcetype).not_to receive(:create)
+      expect_any_instance_of(resource_type).to receive(:update)
+      expect_any_instance_of(resource_type).not_to receive(:create)
       expect(provider.create).to be
     end
 
     it 'should be able to create a server profile with default name using the template' do
       server_profile = OneviewSDK::ServerProfile.new(@client, name: 'Server_Profile_created_from_SPT')
       allow(OneviewSDK::ServerProfile).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:new_profile).and_return(server_profile)
+      allow_any_instance_of(resource_type).to receive(:new_profile).and_return(server_profile)
       allow(server_profile).to receive(:create).and_return(server_profile)
       expect(provider.set_new_profile).to be
     end
@@ -112,7 +112,7 @@ describe provider_class, unit: true do
       resource['data']['serverProfileName'] = 'New Server Profile'
       server_profile = OneviewSDK::ServerProfile.new(@client, name: 'New Server Profile')
       allow(OneviewSDK::ServerProfile).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:new_profile).and_return(server_profile)
+      allow_any_instance_of(resource_type).to receive(:new_profile).and_return(server_profile)
       allow(server_profile).to receive(:create).and_return(server_profile)
       expect(provider.set_new_profile).to be
     end
@@ -130,15 +130,15 @@ describe provider_class, unit: true do
         'serverHardwareTypeUri' => 'SY 480 Gen9 1'
       }
       fake_server_profile = { 'name' => 'Fake profile template with a new configuration' }
-      allow_any_instance_of(resourcetype).to receive(:get_transformation).and_return(fake_server_profile)
+      allow_any_instance_of(resource_type).to receive(:get_transformation).and_return(fake_server_profile)
       expect(provider.get_transformation).to be
     end
 
     it 'should be able to delete the resource' do
       resource['data'] = { 'name' => 'SPT', 'uri' => '/rest/fake' }
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).and_return([test])
-      expect_any_instance_of(resourcetype).to receive(:delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).and_return([test])
+      expect_any_instance_of(resource_type).to receive(:delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.destroy).to be
     end
   end

--- a/spec/unit/provider/oneview_server_profile_template_c7000_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_template_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_profile_template).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:ServerProfileTemplate, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:ServerProfileTemplate, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_server_profile_template_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_template_synergy_spec.rb
@@ -21,7 +21,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_profile_template).provider(:synergy)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:ServerProfileTemplate, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:ServerProfileTemplate, api_version, 'Synergy')
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
@@ -46,10 +46,10 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, resource['data']) }
+    let(:test) { resource_type.new(@client, resource['data']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -58,7 +58,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should run exists? and return the resource does not exist' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
@@ -71,36 +71,36 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(resourcetype.new(@client, resource['data']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(resource_type.new(@client, resource['data']))
       expect(provider.exists?).to eq(false)
       expect(provider.create).to be
     end
 
     it 'should create when resource does not exist' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
-      expect_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      expect_any_instance_of(resource_type).to receive(:create).and_return(test)
       expect(provider.create).to be
     end
 
     it 'should not create when resource is compliant' do
       expect(provider.exists?).to eq(true)
-      expect(resourcetype).not_to receive(:create)
+      expect(resource_type).not_to receive(:create)
       expect(provider.create).to be
     end
 
     it 'should update when resource is not compliant' do
       test['description'] = 'new description'
-      expect_any_instance_of(resourcetype).to receive(:update)
-      expect_any_instance_of(resourcetype).not_to receive(:create)
+      expect_any_instance_of(resource_type).to receive(:update)
+      expect_any_instance_of(resource_type).not_to receive(:create)
       expect(provider.create).to be
     end
 
     it 'should be able to create a server profile with default name using the template' do
       server_profile = OneviewSDK::ServerProfile.new(@client, name: 'Server_Profile_created_from_SPT')
       allow(OneviewSDK::ServerProfile).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:new_profile).and_return(server_profile)
+      allow_any_instance_of(resource_type).to receive(:new_profile).and_return(server_profile)
       allow(server_profile).to receive(:create).and_return(server_profile)
       expect(provider.set_new_profile).to be
     end
@@ -115,7 +115,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
       resource['data']['serverProfileName'] = 'New Server Profile'
       server_profile = OneviewSDK::ServerProfile.new(@client, name: 'New Server Profile')
       allow(OneviewSDK::ServerProfile).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:new_profile).and_return(server_profile)
+      allow_any_instance_of(resource_type).to receive(:new_profile).and_return(server_profile)
       allow(server_profile).to receive(:create).and_return(server_profile)
       expect(provider.set_new_profile).to be
     end
@@ -133,15 +133,15 @@ describe provider_class, unit: true, if: api_version >= 300 do
         'serverHardwareTypeUri' => 'SY 480 Gen9 1'
       }
       fake_server_profile = { 'name' => 'Fake profile template with a new configuration' }
-      allow_any_instance_of(resourcetype).to receive(:get_transformation).and_return(fake_server_profile)
+      allow_any_instance_of(resource_type).to receive(:get_transformation).and_return(fake_server_profile)
       expect(provider.get_transformation).to be
     end
 
     it 'should be able to delete the resource' do
       resource['data'] = { 'name' => 'SPT', 'uri' => '/rest/fake' }
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      expect_any_instance_of(resourcetype).to receive(:delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      expect_any_instance_of(resource_type).to receive(:delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.destroy).to be
     end
   end

--- a/spec/unit/provider/oneview_server_profile_template_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_template_synergy_spec.rb
@@ -14,14 +14,11 @@
 # limitations under the License.
 ################################################################################
 
-# TODO: review and complete with remaining methods for code coverage 80%+
-# (additional SPT methods)
-
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_server_profile_template).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:ServerProfileTemplate, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:ServerProfileTemplate, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_server_profile_template_synergy_spec.rb
+++ b/spec/unit/provider/oneview_server_profile_template_synergy_spec.rb
@@ -18,13 +18,10 @@
 # (additional SPT methods)
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_server_profile_template).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_name = 'ServerProfileTemplate'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resourcetype = OneviewSDK.resource_named(:ServerProfileTemplate, api_version, 'Synergy')
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_storage_pool_c7000_spec.rb
+++ b/spec/unit/provider/oneview_storage_pool_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_storage_pool).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:StoragePool, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:StoragePool, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_storage_pool_c7000_spec.rb
+++ b/spec/unit/provider/oneview_storage_pool_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_storage_pool).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:StoragePool, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:StoragePool, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -41,11 +41,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -62,25 +62,25 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
-      expect_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      expect_any_instance_of(resource_type).to receive(:retrieve!).and_return(false)
+      expect_any_instance_of(resource_type).to receive(:add).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to destroy and recreate the resource to update its atributes' do
-      expect(resourcetype).to receive(:find_by).and_return([])
-      expect(resourcetype).to receive(:find_by).and_return([test])
-      allow_any_instance_of(resourcetype).to receive(:remove).and_return(true)
-      expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      expect(resource_type).to receive(:find_by).and_return([])
+      expect(resource_type).to receive(:find_by).and_return([test])
+      allow_any_instance_of(resource_type).to receive(:remove).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:retrieve!).and_return(false)
+      allow_any_instance_of(resource_type).to receive(:add).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should delete the resource' do
-      allow_any_instance_of(resourcetype).to receive(:remove).and_return([])
+      allow_any_instance_of(resource_type).to receive(:remove).and_return([])
       expect(provider.destroy).to be
     end
   end

--- a/spec/unit/provider/oneview_storage_pool_c7000_spec.rb
+++ b/spec/unit/provider/oneview_storage_pool_c7000_spec.rb
@@ -15,17 +15,10 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_storage_pool).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_name = 'StoragePool'
-resourcetype = if api_version == 200
-                 Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-               else
-                 Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-               end
+resourcetype = OneviewSDK.resource_named(:StoragePool, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -70,15 +63,17 @@ describe provider_class, unit: true do
 
     it 'should be able to create the resource' do
       allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
+      expect_any_instance_of(resourcetype).to receive(:add).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to destroy and recreate the resource to update its atributes' do
       expect(resourcetype).to receive(:find_by).and_return([])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['name']).and_return(test)
-      allow_any_instance_of(resourcetype).to receive(:remove).and_return([])
+      expect(resourcetype).to receive(:find_by).and_return([test])
+      allow_any_instance_of(resourcetype).to receive(:remove).and_return(true)
+      expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
       allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
       provider.exists?
       expect(provider.create).to be

--- a/spec/unit/provider/oneview_storage_pool_synergy_spec.rb
+++ b/spec/unit/provider/oneview_storage_pool_synergy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_storage_pool).provider(:synergy)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:StoragePool, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:StoragePool, api_version, 'Synergy')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -41,11 +41,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -62,25 +62,25 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
-      expect_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      expect_any_instance_of(resource_type).to receive(:retrieve!).and_return(false)
+      expect_any_instance_of(resource_type).to receive(:add).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to destroy and recreate the resource to update its atributes' do
-      expect(resourcetype).to receive(:find_by).and_return([])
-      expect(resourcetype).to receive(:find_by).and_return([test])
-      allow_any_instance_of(resourcetype).to receive(:remove).and_return(true)
-      expect_any_instance_of(resourcetype).to receive(:retrieve!).and_return(false)
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      expect(resource_type).to receive(:find_by).and_return([])
+      expect(resource_type).to receive(:find_by).and_return([test])
+      allow_any_instance_of(resource_type).to receive(:remove).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:retrieve!).and_return(false)
+      allow_any_instance_of(resource_type).to receive(:add).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should delete the resource' do
-      allow_any_instance_of(resourcetype).to receive(:remove).and_return([])
+      allow_any_instance_of(resource_type).to receive(:remove).and_return([])
       expect(provider.destroy).to be
     end
   end

--- a/spec/unit/provider/oneview_storage_pool_synergy_spec.rb
+++ b/spec/unit/provider/oneview_storage_pool_synergy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_storage_pool).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:StoragePool, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:StoragePool, api_version, :Synergy)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_storage_system_c7000_spec.rb
+++ b/spec/unit/provider/oneview_storage_system_c7000_spec.rb
@@ -21,11 +21,11 @@ require_relative '../../shared_context'
 provider_class = Puppet::Type.type(:oneview_storage_system).provider(:oneview_storage_system)
 api_version = login[:api_version] || 200
 resource_name = 'StorageSystem'
-resourcetype = if api_version == 200
-                 Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-               else
-                 Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-               end
+resource_type = if api_version == 200
+                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
+                else
+                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
+                end
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -52,11 +52,11 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -73,29 +73,29 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to delete the resource' do
-      allow_any_instance_of(resourcetype).to receive(:remove).and_return([])
+      allow_any_instance_of(resource_type).to receive(:remove).and_return([])
       provider.exists?
       expect(provider.destroy).to be
     end
 
     it 'should be able to get the storage pools' do
-      allow_any_instance_of(resourcetype).to receive(:get_storage_pools).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_storage_pools).and_return('Test')
       expect(provider.get_storage_pools).to be
     end
 
     it 'should be able to get the managed ports' do
-      allow_any_instance_of(resourcetype).to receive(:get_managed_ports).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_managed_ports).and_return('Test')
       expect(provider.get_managed_ports).to be
     end
 
     it 'should be able to get the storage pools' do
-      allow(resourcetype).to receive(:get_host_types).and_return('Test')
+      allow(resource_type).to receive(:get_host_types).and_return('Test')
       expect(provider.get_host_types).to be
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end

--- a/spec/unit/provider/oneview_storage_system_c7000_spec.rb
+++ b/spec/unit/provider/oneview_storage_system_c7000_spec.rb
@@ -15,17 +15,10 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
-provider_class = Puppet::Type.type(:oneview_storage_system).provider(:oneview_storage_system)
+provider_class = Puppet::Type.type(:oneview_storage_system).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_name = 'StorageSystem'
-resource_type = if api_version == 200
-                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-                else
-                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-                end
+resource_type = OneviewSDK.resource_named(:StorageSystem, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_storage_system_synergy_spec.rb
+++ b/spec/unit/provider/oneview_storage_system_synergy_spec.rb
@@ -15,13 +15,10 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
-provider_class = Puppet::Type.type(:oneview_storage_system).provider(:oneview_storage_system)
+provider_class = Puppet::Type.type(:oneview_storage_system).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_name = 'StorageSystem'
-resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version == 200
+resource_type = OneviewSDK.resource_named(:StorageSystem, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_storage_system_synergy_spec.rb
+++ b/spec/unit/provider/oneview_storage_system_synergy_spec.rb
@@ -21,7 +21,7 @@ require_relative '../../shared_context'
 provider_class = Puppet::Type.type(:oneview_storage_system).provider(:oneview_storage_system)
 api_version = login[:api_version] || 200
 resource_name = 'StorageSystem'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version == 200
+resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version == 200
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
@@ -48,11 +48,11 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -69,29 +69,29 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should be able to delete the resource' do
-      allow_any_instance_of(resourcetype).to receive(:remove).and_return([])
+      allow_any_instance_of(resource_type).to receive(:remove).and_return([])
       provider.exists?
       expect(provider.destroy).to be
     end
 
     it 'should be able to get the storage pools' do
-      allow_any_instance_of(resourcetype).to receive(:get_storage_pools).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_storage_pools).and_return('Test')
       expect(provider.get_storage_pools).to be
     end
 
     it 'should be able to get the managed ports' do
-      allow_any_instance_of(resourcetype).to receive(:get_managed_ports).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_managed_ports).and_return('Test')
       expect(provider.get_managed_ports).to be
     end
 
     it 'should be able to get the storage pools' do
-      allow(resourcetype).to receive(:get_host_types).and_return('Test')
+      allow(resource_type).to receive(:get_host_types).and_return('Test')
       expect(provider.get_host_types).to be
     end
 
     it 'should be able to create the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end

--- a/spec/unit/provider/oneview_switch_c7000_spec.rb
+++ b/spec/unit/provider/oneview_switch_c7000_spec.rb
@@ -16,14 +16,9 @@
 
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:oneview_switch).provider(:oneview_switch)
+provider_class = Puppet::Type.type(:oneview_switch).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_name = 'Switch'
-resource_type = if api_version == 200
-                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-                else
-                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-                end
+resource_type = OneviewSDK.resource_named(:Switch, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_switch_c7000_spec.rb
+++ b/spec/unit/provider/oneview_switch_c7000_spec.rb
@@ -19,11 +19,11 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:oneview_switch).provider(:oneview_switch)
 api_version = login[:api_version] || 200
 resource_name = 'Switch'
-resourcetype = if api_version == 200
-                 Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-               else
-                 Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-               end
+resource_type = if api_version == 200
+                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
+                else
+                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
+                end
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -44,10 +44,10 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   before(:each) do
-    allow(resourcetype).to receive(:find_by).and_return([test])
+    allow(resource_type).to receive(:find_by).and_return([test])
     provider.exists?
   end
 
@@ -65,7 +65,7 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to get type for a specific switch' do
-      allow(resourcetype).to receive(:get_type).and_return(test)
+      allow(resource_type).to receive(:get_type).and_return(test)
       provider.exists?
       expect(provider.get_type).to be
     end
@@ -74,8 +74,8 @@ describe provider_class, unit: true do
       path = 'spec/support/fixtures/unit/provider/ethernet_network_members.json'
       Test = File.read(path)
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new(Test))
       expect(provider.exists?).to eq(true)
       expect(provider.get_environmental_configuration).to be
@@ -83,8 +83,8 @@ describe provider_class, unit: true do
 
     it 'should drop the Switch' do
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       expect(provider.exists?).to eq(true)
       expect(provider.destroy).to be
@@ -104,12 +104,12 @@ describe provider_class, unit: true do
       )
     end
     it 'exists? should not find the Switch' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).not_to be
     end
 
     it 'should fail and return that the Switch was not found' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).not_to be
       expect { provider.found }.to raise_error(/No Switch with the specified data were found on the Oneview Appliance/)
     end
@@ -117,14 +117,14 @@ describe provider_class, unit: true do
 
   context 'given the create parameters' do
     it 'should be able to run through self.instances' do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:get_all).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:get_all).and_return([test])
       expect(instance).to be
     end
 
     it 'should return an error stating that no types match the name given' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow(resourcetype).to receive(:get_type).with(anything, resource['data']['name']).and_return(nil)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:get_type).with(anything, resource['data']['name']).and_return(nil)
       provider.exists?
       expect { provider.get_type }
         .to raise_error(/\n\n No switch types corresponding to the name #{resource['data']['name']} were found.\n/)
@@ -141,7 +141,7 @@ describe provider_class, unit: true do
       )
     end
     it 'should be able to get types' do
-      allow(resourcetype).to receive(:get_types).and_return(test)
+      allow(resource_type).to receive(:get_types).and_return(test)
       provider.exists?
       expect(provider.get_type).to be
     end
@@ -162,7 +162,7 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to get types' do
-      allow_any_instance_of(resourcetype).to receive(:set_scope_uris).and_return(test)
+      allow_any_instance_of(resource_type).to receive(:set_scope_uris).and_return(test)
       provider.exists?
       expect(provider.set_scope_uris).to be
     end
@@ -188,8 +188,8 @@ describe provider_class, unit: true do
         'name'                      => '172.18.20.1',
         'uri'                       => '/rest/fake'
       }
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, data_for_findby).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, data_for_findby).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new('Fake Get Statistics'))
       provider.exists?
       expect(provider.get_statistics).to be

--- a/spec/unit/provider/oneview_switch_synergy_spec.rb
+++ b/spec/unit/provider/oneview_switch_synergy_spec.rb
@@ -18,8 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_switch).provider(:oneview_switch)
 api_version = login[:api_version] || 200
-resource_name = 'Switch'
-resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = OneviewSDK.resource_named(:Switch, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_switch_synergy_spec.rb
+++ b/spec/unit/provider/oneview_switch_synergy_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:oneview_switch).provider(:oneview_switch)
 api_version = login[:api_version] || 200
 resource_name = 'Switch'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
@@ -65,7 +65,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
       )
     end
     it 'should be able to get type for a specific switch' do
-      allow(resourcetype).to receive(:get_type).and_return(['fake_type'])
+      allow(resource_type).to receive(:get_type).and_return(['fake_type'])
       provider.exists?
       expect(provider.get_type).to be
     end
@@ -81,7 +81,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
       )
     end
     it 'should be able to get types' do
-      allow(resourcetype).to receive(:get_types).and_return(['fake_type'])
+      allow(resource_type).to receive(:get_types).and_return(['fake_type'])
       provider.exists?
       expect(provider.get_type).to be
     end

--- a/spec/unit/provider/oneview_unmanaged_device_c7000_spec.rb
+++ b/spec/unit/provider/oneview_unmanaged_device_c7000_spec.rb
@@ -15,11 +15,10 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_unmanaged_device).provider(:c7000)
-resourcetype = OneviewSDK::UnmanagedDevice
+api_version = login[:api_version] || 200
+resourcetype = OneviewSDK.resource_named(:UnmanagedDevice, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -52,6 +51,10 @@ describe provider_class, unit: true do
       provider.exists?
     end
 
+    it 'should be able to run through self.instances' do
+      expect(instance).to be
+    end
+
     it 'should be an instance of the provider' do
       expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_unmanaged_device).provider(:c7000)
     end
@@ -80,9 +83,8 @@ describe provider_class, unit: true do
     end
 
     it 'should update the resource' do
-      unique_ids = { 'name' => resource['data']['name'], 'uri' => resource['data']['uri'] }
-      expect(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
-      expect(resourcetype).to receive(:find_by).with(anything, unique_ids).and_return([test])
+      expect_any_instance_of(resourcetype).to receive(:like?).and_return(false)
+      expect_any_instance_of(resourcetype).to receive(:update).and_return(true)
       provider.exists?
       expect(provider.create).to be
     end

--- a/spec/unit/provider/oneview_unmanaged_device_c7000_spec.rb
+++ b/spec/unit/provider/oneview_unmanaged_device_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_unmanaged_device).provider(:c7000)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:UnmanagedDevice, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:UnmanagedDevice, api_version, 'C7000')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -43,11 +43,11 @@ describe provider_class, unit: true do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, name: resource['data']['name']) }
+    let(:test) { resource_type.new(@client, name: resource['data']['name']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
-      allow_any_instance_of(resourcetype).to receive(:update).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
+      allow_any_instance_of(resource_type).to receive(:update).and_return([test])
       provider.exists?
     end
 
@@ -65,32 +65,32 @@ describe provider_class, unit: true do
     end
 
     it 'should not be able to find the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       provider.exists?
       expect { provider.found }.to raise_error(/No UnmanagedDevice with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should delete/remove the resource' do
-      allow_any_instance_of(resourcetype).to receive(:remove).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:remove).and_return(true)
       expect(provider.destroy).to be
     end
 
     it 'should create/add the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should update the resource' do
-      expect_any_instance_of(resourcetype).to receive(:like?).and_return(false)
-      expect_any_instance_of(resourcetype).to receive(:update).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:like?).and_return(false)
+      expect_any_instance_of(resource_type).to receive(:update).and_return(true)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to get the environmental configuration' do
-      allow_any_instance_of(resourcetype).to receive(:environmental_configuration).and_return(['test'])
+      allow_any_instance_of(resource_type).to receive(:environmental_configuration).and_return(['test'])
       provider.exists?
       expect(provider.get_environmental_configuration).to be
     end

--- a/spec/unit/provider/oneview_unmanaged_device_c7000_spec.rb
+++ b/spec/unit/provider/oneview_unmanaged_device_c7000_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_unmanaged_device).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:UnmanagedDevice, api_version, 'C7000')
+resource_type = OneviewSDK.resource_named(:UnmanagedDevice, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_unmanaged_device_synergy_spec.rb
+++ b/spec/unit/provider/oneview_unmanaged_device_synergy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_unmanaged_device).provider(:synergy)
 api_version = login[:api_version] || 200
-resourcetype = OneviewSDK.resource_named(:UnmanagedDevice, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:UnmanagedDevice, api_version, 'Synergy')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -43,11 +43,11 @@ describe provider_class, unit: true do
 
     let(:instance) { provider.class.instances.first }
 
-    let(:test) { resourcetype.new(@client, name: resource['data']['name']) }
+    let(:test) { resource_type.new(@client, name: resource['data']['name']) }
 
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
-      allow_any_instance_of(resourcetype).to receive(:update).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
+      allow_any_instance_of(resource_type).to receive(:update).and_return([test])
       provider.exists?
     end
 
@@ -65,32 +65,32 @@ describe provider_class, unit: true do
     end
 
     it 'should not be able to find the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       provider.exists?
       expect { provider.found }.to raise_error(/No UnmanagedDevice with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should delete/remove the resource' do
-      allow_any_instance_of(resourcetype).to receive(:remove).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:remove).and_return(true)
       expect(provider.destroy).to be
     end
 
     it 'should create/add the resource' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:add).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:add).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should update the resource' do
-      expect_any_instance_of(resourcetype).to receive(:like?).and_return(false)
-      expect_any_instance_of(resourcetype).to receive(:update).and_return(true)
+      expect_any_instance_of(resource_type).to receive(:like?).and_return(false)
+      expect_any_instance_of(resource_type).to receive(:update).and_return(true)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to get the environmental configuration' do
-      allow_any_instance_of(resourcetype).to receive(:environmental_configuration).and_return(['test'])
+      allow_any_instance_of(resource_type).to receive(:environmental_configuration).and_return(['test'])
       provider.exists?
       expect(provider.get_environmental_configuration).to be
     end

--- a/spec/unit/provider/oneview_unmanaged_device_synergy_spec.rb
+++ b/spec/unit/provider/oneview_unmanaged_device_synergy_spec.rb
@@ -18,9 +18,9 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_unmanaged_device).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_type = OneviewSDK.resource_named(:UnmanagedDevice, api_version, 'Synergy')
+resource_type = OneviewSDK.resource_named(:UnmanagedDevice, api_version, :Synergy)
 
-describe provider_class, unit: true do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   context 'given the add parameters' do

--- a/spec/unit/provider/oneview_unmanaged_device_synergy_spec.rb
+++ b/spec/unit/provider/oneview_unmanaged_device_synergy_spec.rb
@@ -15,11 +15,10 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_unmanaged_device).provider(:synergy)
-resourcetype = OneviewSDK::UnmanagedDevice
+api_version = login[:api_version] || 200
+resourcetype = OneviewSDK.resource_named(:UnmanagedDevice, api_version, 'Synergy')
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -52,6 +51,10 @@ describe provider_class, unit: true do
       provider.exists?
     end
 
+    it 'should be able to run through self.instances' do
+      expect(instance).to be
+    end
+
     it 'should be an instance of the provider' do
       expect(provider).to be_an_instance_of Puppet::Type.type(:oneview_unmanaged_device).provider(:synergy)
     end
@@ -80,9 +83,8 @@ describe provider_class, unit: true do
     end
 
     it 'should update the resource' do
-      unique_ids = { 'name' => resource['data']['name'], 'uri' => resource['data']['uri'] }
-      expect(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([])
-      expect(resourcetype).to receive(:find_by).with(anything, unique_ids).and_return([test])
+      expect_any_instance_of(resourcetype).to receive(:like?).and_return(false)
+      expect_any_instance_of(resourcetype).to receive(:update).and_return(true)
       provider.exists?
       expect(provider.create).to be
     end

--- a/spec/unit/provider/oneview_uplink_set_c7000_spec.rb
+++ b/spec/unit/provider/oneview_uplink_set_c7000_spec.rb
@@ -21,11 +21,11 @@ require_relative '../../shared_context'
 provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:c7000)
 api_version = login[:api_version] || 200
 resource_name = 'UplinkSet'
-resourcetype = if api_version == 200
-                 Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-               else
-                 Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-               end
+resource_type = if api_version == 200
+                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
+                else
+                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
+                end
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -78,14 +78,14 @@ describe provider_class, unit: true do
     end
 
     it 'should return false if resource does not exist' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
       expect { provider.found }.to raise_error(/No UplinkSet with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should return true if resource exists / is found' do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
       expect(provider.found).to eq(true)
     end
@@ -93,8 +93,8 @@ describe provider_class, unit: true do
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
       test = OneviewSDK::UplinkSet.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be
@@ -133,12 +133,12 @@ describe provider_class, unit: true do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       fc_network = OneviewSDK::FCNetwork.new(@client, name: 'Puppet Test FCNetwork', uri: '/rest/fc-networks/fake')
       logint = OneviewSDK::LogicalInterconnect.new(@client, name: 'Encl1-Test Oneview', uri: '/rest/logical-interconnects/fake')
       allow(OneviewSDK::FCNetwork).to receive(:find_by).and_return([fc_network])
       allow(OneviewSDK::LogicalInterconnect).to receive(:find_by).and_return([logint])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(OneviewSDK::UplinkSet.new(@client, resource['data']))
+      allow_any_instance_of(resource_type).to receive(:create).and_return(OneviewSDK::UplinkSet.new(@client, resource['data']))
       provider.exists?
       expect(provider.create).to eq(true)
     end
@@ -176,12 +176,12 @@ describe provider_class, unit: true do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       fcoe_network = OneviewSDK::FCoENetwork.new(@client, name: 'Puppet Test FCoENetwork', uri: '/rest/fcoe-networks/fake')
       logint = OneviewSDK::LogicalInterconnect.new(@client, name: 'Encl1-Test Oneview', uri: '/rest/logical-interconnects/fake')
       allow(OneviewSDK::FCoENetwork).to receive(:find_by).and_return([fcoe_network])
       allow(OneviewSDK::LogicalInterconnect).to receive(:find_by).and_return([logint])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(OneviewSDK::UplinkSet.new(@client, resource['data']))
+      allow_any_instance_of(resource_type).to receive(:create).and_return(OneviewSDK::UplinkSet.new(@client, resource['data']))
       provider.exists?
       expect(provider.create).to eq(true)
     end

--- a/spec/unit/provider/oneview_uplink_set_c7000_spec.rb
+++ b/spec/unit/provider/oneview_uplink_set_c7000_spec.rb
@@ -15,17 +15,10 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_name = 'UplinkSet'
-resource_type = if api_version == 200
-                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-                else
-                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-                end
+resource_type = OneviewSDK.resource_named(:UplinkSet, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_uplink_set_synergy_spec.rb
+++ b/spec/unit/provider/oneview_uplink_set_synergy_spec.rb
@@ -21,7 +21,7 @@ require_relative '../../shared_context'
 provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:synergy)
 api_version = login[:api_version] || 200
 resource_name = 'UplinkSet'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
@@ -74,14 +74,14 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should return false if resource does not exist' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
       expect { provider.found }.to raise_error(/No UplinkSet with the specified data were found on the Oneview Appliance/)
     end
 
     it 'should return true if resource exists / is found' do
       test = OneviewSDK::UplinkSet.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       expect(provider.exists?).to be
       expect(provider.found).to eq(true)
     end
@@ -89,8 +89,8 @@ describe provider_class, unit: true, if: api_version >= 300 do
     it 'deletes the resource' do
       resource['data']['uri'] = '/rest/fake'
       test = OneviewSDK::UplinkSet.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      allow(resourcetype).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(FakeResponse.new('uri' => '/rest/fake'))
       provider.exists?
       expect(provider.destroy).to be
@@ -129,12 +129,12 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       fc_network = OneviewSDK::FCNetwork.new(@client, name: 'Puppet Test FCNetwork', uri: '/rest/fc-networks/fake')
       logint = OneviewSDK::LogicalInterconnect.new(@client, name: 'Encl1-Test Oneview', uri: '/rest/logical-interconnects/fake')
       allow(OneviewSDK::FCNetwork).to receive(:find_by).and_return([fc_network])
       allow(OneviewSDK::LogicalInterconnect).to receive(:find_by).and_return([logint])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(OneviewSDK::UplinkSet.new(@client, resource['data']))
+      allow_any_instance_of(resource_type).to receive(:create).and_return(OneviewSDK::UplinkSet.new(@client, resource['data']))
       provider.exists?
       expect(provider.create).to eq(true)
     end
@@ -172,12 +172,12 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       fcoe_network = OneviewSDK::FCoENetwork.new(@client, name: 'Puppet Test FCoENetwork', uri: '/rest/fcoe-networks/fake')
       logint = OneviewSDK::LogicalInterconnect.new(@client, name: 'Encl1-Test Oneview', uri: '/rest/logical-interconnects/fake')
       allow(OneviewSDK::FCoENetwork).to receive(:find_by).and_return([fcoe_network])
       allow(OneviewSDK::LogicalInterconnect).to receive(:find_by).and_return([logint])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(OneviewSDK::UplinkSet.new(@client, resource['data']))
+      allow_any_instance_of(resource_type).to receive(:create).and_return(OneviewSDK::UplinkSet.new(@client, resource['data']))
       provider.exists?
       expect(provider.create).to eq(true)
     end

--- a/spec/unit/provider/oneview_uplink_set_synergy_spec.rb
+++ b/spec/unit/provider/oneview_uplink_set_synergy_spec.rb
@@ -15,13 +15,10 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_uplink_set).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_name = 'UplinkSet'
-resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = OneviewSDK.resource_named(:UplinkSet, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_volume_attachment_c7000_spec.rb
+++ b/spec/unit/provider/oneview_volume_attachment_c7000_spec.rb
@@ -23,7 +23,7 @@ describe provider_class, unit: true do
   include_context 'shared context'
 
   resource_name = 'VolumeAttachment'
-  resourcetype = Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}") unless api_version < 300
+  resource_type = Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}") unless api_version < 300
 
   let(:resource) do
     Puppet::Type.type(:oneview_volume_attachment).new(
@@ -41,21 +41,21 @@ describe provider_class, unit: true do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
     it 'should able to find the specific VA' do
       resource['data']['sanStorage'] = { 'volumeAttachments' => [{ 'volumeUri' => 'fake uri' }] }
       resource['data']['uri'] = 'fake uri'
-      test = resourcetype.new(@client, resource['data'])
+      test = resource_type.new(@client, resource['data'])
       resource['data'].delete('sanStorage')
       resource['data'].delete('uri')
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       allow(OneviewSDK::ServerProfile).to receive(:find_by).with(anything, name: 'Server Profile Attachment Demo').and_return([test])
       allow(OneviewSDK::Volume).to receive(:find_by).with(anything, name: 'volume-attachment-demo').and_return([test])
       expect(provider.found).to be
@@ -79,13 +79,13 @@ describe provider_class, unit: true do
     end
 
     it 'should be able to get a list of extra unmanaged volumes' do
-      expect(resourcetype).to receive(:get_extra_unmanaged_volumes).and_return('members' => ['uri' => '/rest/fake'])
+      expect(resource_type).to receive(:get_extra_unmanaged_volumes).and_return('members' => ['uri' => '/rest/fake'])
       expect(provider.get_extra_unmanaged_volumes).to be
     end
 
     it 'should be able to remove the extra unmanaged volumes' do
       allow(OneviewSDK::ServerProfile).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
-      expect(resourcetype).to receive(:remove_extra_unmanaged_volume)
+      expect(resource_type).to receive(:remove_extra_unmanaged_volume)
       expect(provider.remove_extra_unmanaged_volume).to be
     end
   end
@@ -100,8 +100,8 @@ describe provider_class, unit: true do
     end
 
     it 'should able to find all VAs' do
-      test = resourcetype.new(@client, {})
-      allow(resourcetype).to receive(:find_by).with(anything, {}).and_return([test])
+      test = resource_type.new(@client, {})
+      allow(resource_type).to receive(:find_by).with(anything, {}).and_return([test])
       expect(provider.found).to be
     end
   end
@@ -123,16 +123,16 @@ describe provider_class, unit: true do
     it 'should be able to get all paths if no id is provided' do
       resource['data'] = { 'name' => 'ONEVIEW_PUPPET_TEST VA1' }
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      expect_any_instance_of(resourcetype).to receive(:get_paths).and_return(['/rest/fake1', '/rest/fake2'])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      expect_any_instance_of(resource_type).to receive(:get_paths).and_return(['/rest/fake1', '/rest/fake2'])
       provider.exists?
       expect(provider.get_paths).to be
     end
 
     it 'should be able to get a path by id if id is provided' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      expect_any_instance_of(resourcetype).to receive(:get_path).and_return(['/rest/fake1'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      expect_any_instance_of(resource_type).to receive(:get_path).and_return(['/rest/fake1'])
       provider.exists?
       expect(provider.get_paths).to be
     end

--- a/spec/unit/provider/oneview_volume_attachment_c7000_spec.rb
+++ b/spec/unit/provider/oneview_volume_attachment_c7000_spec.rb
@@ -18,17 +18,15 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_volume_attachment).provider(:c7000)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:VolumeAttachment, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'
 
-  resource_name = 'VolumeAttachment'
-  resource_type = Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}") unless api_version < 300
-
   let(:resource) do
     Puppet::Type.type(:oneview_volume_attachment).new(
       name: 'VA',
-      ensure: 'present',
+      ensure: 'found',
       data:
           {
             'name' => 'Server Profile Attachment Demo, volume-attachment-demo'
@@ -59,16 +57,6 @@ describe provider_class, unit: true do
       allow(OneviewSDK::ServerProfile).to receive(:find_by).with(anything, name: 'Server Profile Attachment Demo').and_return([test])
       allow(OneviewSDK::Volume).to receive(:find_by).with(anything, name: 'volume-attachment-demo').and_return([test])
       expect(provider.found).to be
-    end
-
-    it 'should raise an error if the ensurable present is used' do
-      resource['ensure'] = 'present'
-      expect { provider.create }.to raise_error(/Ensure state 'present' is unavailable for this resource/)
-    end
-
-    it 'should raise an error if the ensurable absent is used' do
-      resource['ensure'] = 'absent'
-      expect { provider.destroy }.to raise_error(/Ensure state 'absent' is unavailable for this resource/)
     end
 
     it 'should raise an error if there is no name for server profile' do

--- a/spec/unit/provider/oneview_volume_attachment_synergy_spec.rb
+++ b/spec/unit/provider/oneview_volume_attachment_synergy_spec.rb
@@ -13,21 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+
 require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_volume_attachment).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:VolumeAttachment, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  resource_name = 'VolumeAttachment'
-  resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
-
   let(:resource) do
     Puppet::Type.type(:oneview_volume_attachment).new(
       name: 'VA',
-      ensure: 'present',
+      ensure: 'found',
       data:
           {
             'name' => 'Server Profile Attachment Demo, volume-attachment-demo'
@@ -58,16 +57,6 @@ describe provider_class, unit: true, if: api_version >= 300 do
       allow(OneviewSDK::ServerProfile).to receive(:find_by).with(anything, name: 'Server Profile Attachment Demo').and_return([test])
       allow(OneviewSDK::Volume).to receive(:find_by).with(anything, name: 'volume-attachment-demo').and_return([test])
       expect(provider.found).to be
-    end
-
-    it 'should raise an error if the ensurable present is used' do
-      resource['ensure'] = 'present'
-      expect { provider.create }.to raise_error(/Ensure state 'present' is unavailable for this resource/)
-    end
-
-    it 'should raise an error if the ensurable absent is used' do
-      resource['ensure'] = 'absent'
-      expect { provider.destroy }.to raise_error(/Ensure state 'absent' is unavailable for this resource/)
     end
 
     it 'should raise an error if there is no name for server profile' do

--- a/spec/unit/provider/oneview_volume_attachment_synergy_spec.rb
+++ b/spec/unit/provider/oneview_volume_attachment_synergy_spec.rb
@@ -22,7 +22,7 @@ describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
   resource_name = 'VolumeAttachment'
-  resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+  resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
 
   let(:resource) do
     Puppet::Type.type(:oneview_volume_attachment).new(
@@ -40,21 +40,21 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the minimum parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
     it 'should able to find the specific VA' do
       resource['data']['sanStorage'] = { 'volumeAttachments' => [{ 'volumeUri' => 'fake uri' }] }
       resource['data']['uri'] = 'fake uri'
-      test = resourcetype.new(@client, resource['data'])
+      test = resource_type.new(@client, resource['data'])
       resource['data'].delete('sanStorage')
       resource['data'].delete('uri')
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       allow(OneviewSDK::ServerProfile).to receive(:find_by).with(anything, name: 'Server Profile Attachment Demo').and_return([test])
       allow(OneviewSDK::Volume).to receive(:find_by).with(anything, name: 'volume-attachment-demo').and_return([test])
       expect(provider.found).to be
@@ -78,13 +78,13 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should be able to get a list of extra unmanaged volumes' do
-      expect(resourcetype).to receive(:get_extra_unmanaged_volumes).and_return('members' => ['uri' => '/rest/fake'])
+      expect(resource_type).to receive(:get_extra_unmanaged_volumes).and_return('members' => ['uri' => '/rest/fake'])
       expect(provider.get_extra_unmanaged_volumes).to be
     end
 
     it 'should be able to remove the extra unmanaged volumes' do
       allow(OneviewSDK::ServerProfile).to receive(:find_by).with(anything, name: resource['data']['name']).and_return([test])
-      expect(resourcetype).to receive(:remove_extra_unmanaged_volume)
+      expect(resource_type).to receive(:remove_extra_unmanaged_volume)
       expect(provider.remove_extra_unmanaged_volume).to be
     end
   end
@@ -99,8 +99,8 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'should able to find all VAs' do
-      test = resourcetype.new(@client, {})
-      allow(resourcetype).to receive(:find_by).with(anything, {}).and_return([test])
+      test = resource_type.new(@client, {})
+      allow(resource_type).to receive(:find_by).with(anything, {}).and_return([test])
       expect(provider.found).to be
     end
   end
@@ -122,16 +122,16 @@ describe provider_class, unit: true, if: api_version >= 300 do
     it 'should be able to get all paths if no id is provided' do
       resource['data'] = { 'name' => 'ONEVIEW_PUPPET_TEST VA1' }
       resource['data']['uri'] = '/rest/fake'
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      expect_any_instance_of(resourcetype).to receive(:get_paths).and_return(['/rest/fake1', '/rest/fake2'])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      expect_any_instance_of(resource_type).to receive(:get_paths).and_return(['/rest/fake1', '/rest/fake2'])
       provider.exists?
       expect(provider.get_paths).to be
     end
 
     it 'should be able to get a path by id if id is provided' do
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
-      expect_any_instance_of(resourcetype).to receive(:get_path).and_return(['/rest/fake1'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      expect_any_instance_of(resource_type).to receive(:get_path).and_return(['/rest/fake1'])
       provider.exists?
       expect(provider.get_paths).to be
     end

--- a/spec/unit/provider/oneview_volume_c7000_spec.rb
+++ b/spec/unit/provider/oneview_volume_c7000_spec.rb
@@ -15,17 +15,10 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_volume).provider(:c7000)
 api_version = login[:api_version] || 200
-resource_name = 'Volume'
-resource_type = if api_version == 200
-                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-                else
-                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-                end
+resource_type = OneviewSDK.resource_named(:Volume, api_version, :C7000)
 
 describe provider_class, unit: true do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_volume_c7000_spec.rb
+++ b/spec/unit/provider/oneview_volume_c7000_spec.rb
@@ -21,11 +21,11 @@ require_relative '../../shared_context'
 provider_class = Puppet::Type.type(:oneview_volume).provider(:c7000)
 api_version = login[:api_version] || 200
 resource_name = 'Volume'
-resourcetype = if api_version == 200
-                 Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
-               else
-                 Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
-               end
+resource_type = if api_version == 200
+                  Object.const_get("OneviewSDK::API#{api_version}::#{resource_name}")
+                else
+                  Object.const_get("OneviewSDK::API#{api_version}::C7000::#{resource_name}")
+                end
 
 describe provider_class, unit: true do
   include_context 'shared context'
@@ -58,14 +58,14 @@ describe provider_class, unit: true do
 
   context 'given the minimum parameters' do
     before(:each) do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
     it 'should be able to run through self.instances' do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, {}).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, {}).and_return([test])
       expect(instance).to be
     end
 
@@ -78,48 +78,48 @@ describe provider_class, unit: true do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(resourcetype.new(@client, resource['data']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(resource_type.new(@client, resource['data']))
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to get the snapshots' do
-      allow_any_instance_of(resourcetype).to receive(:get_snapshots).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_snapshots).and_return('Test')
       expect(provider.get_snapshot).to be
     end
 
     it 'should be able to get a snapshot by name' do
       resource['data']['snapshotParameters'] = { 'name' => 'Snapshot' }
-      allow_any_instance_of(resourcetype).to receive(:get_snapshot).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_snapshot).and_return('Test')
       expect(provider.get_snapshot).to be
     end
 
     it 'should be able to repair' do
-      allow_any_instance_of(resourcetype).to receive(:repair).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:repair).and_return('Test')
       expect(provider.repair).to be
     end
 
     it 'should be able to get the attachable volumes' do
-      allow(resourcetype).to receive(:get_attachable_volumes).with(anything).and_return('Test')
+      allow(resource_type).to receive(:get_attachable_volumes).with(anything).and_return('Test')
       expect(provider.get_attachable_volumes).to be
     end
 
     it 'should be able to get the extra managed volume paths' do
-      allow(resourcetype).to receive(:get_extra_managed_volume_paths).with(anything).and_return('Test')
+      allow(resource_type).to receive(:get_extra_managed_volume_paths).with(anything).and_return('Test')
       expect(provider.get_extra_managed_volume_paths).to be
     end
 
     it 'should delete the snapshot' do
       resource['data']['snapshotParameters'] = { 'name' => 'Snapshot' }
-      allow_any_instance_of(resourcetype).to receive(:delete_snapshot).with(resource['data']['snapshotParameters']['name'])
+      allow_any_instance_of(resource_type).to receive(:delete_snapshot).with(resource['data']['snapshotParameters']['name'])
         .and_return('Test')
       expect(provider.delete_snapshot).to be
     end
 
     it 'should create the snapshot' do
       resource['data']['snapshotParameters'] = { 'name' => 'Snapshot' }
-      allow_any_instance_of(resourcetype).to receive(:create_snapshot).with('name' => resource['data']['snapshotParameters']['name'])
+      allow_any_instance_of(resource_type).to receive(:create_snapshot).with('name' => resource['data']['snapshotParameters']['name'])
         .and_return('Test')
       expect(provider.create_snapshot).to be
     end

--- a/spec/unit/provider/oneview_volume_synergy_spec.rb
+++ b/spec/unit/provider/oneview_volume_synergy_spec.rb
@@ -15,13 +15,10 @@
 ################################################################################
 
 require 'spec_helper'
-require_relative '../../support/fake_response'
-require_relative '../../shared_context'
 
 provider_class = Puppet::Type.type(:oneview_volume).provider(:synergy)
 api_version = login[:api_version] || 200
-resource_name = 'Volume'
-resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = OneviewSDK.resource_named(:Volume, api_version, :Synergy)
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'

--- a/spec/unit/provider/oneview_volume_synergy_spec.rb
+++ b/spec/unit/provider/oneview_volume_synergy_spec.rb
@@ -21,7 +21,7 @@ require_relative '../../shared_context'
 provider_class = Puppet::Type.type(:oneview_volume).provider(:synergy)
 api_version = login[:api_version] || 200
 resource_name = 'Volume'
-resourcetype = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
+resource_type = Object.const_get("OneviewSDK::API#{api_version}::Synergy::#{resource_name}") unless api_version < 300
 
 describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
@@ -54,14 +54,14 @@ describe provider_class, unit: true, if: api_version >= 300 do
 
   context 'given the minimum parameters' do
     before(:each) do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, resource['data']).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, resource['data']).and_return([test])
       provider.exists?
     end
 
     it 'should be able to run through self.instances' do
-      test = resourcetype.new(@client, resource['data'])
-      allow(resourcetype).to receive(:find_by).with(anything, {}).and_return([test])
+      test = resource_type.new(@client, resource['data'])
+      allow(resource_type).to receive(:find_by).with(anything, {}).and_return([test])
       expect(instance).to be
     end
 
@@ -74,48 +74,48 @@ describe provider_class, unit: true, if: api_version >= 300 do
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(resourcetype.new(@client, resource['data']))
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(resource_type.new(@client, resource['data']))
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to get the snapshots' do
-      allow_any_instance_of(resourcetype).to receive(:get_snapshots).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_snapshots).and_return('Test')
       expect(provider.get_snapshot).to be
     end
 
     it 'should be able to get a snapshot by name' do
       resource['data']['snapshotParameters'] = { 'name' => 'Snapshot' }
-      allow_any_instance_of(resourcetype).to receive(:get_snapshot).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:get_snapshot).and_return('Test')
       expect(provider.get_snapshot).to be
     end
 
     it 'should be able to repair' do
-      allow_any_instance_of(resourcetype).to receive(:repair).and_return('Test')
+      allow_any_instance_of(resource_type).to receive(:repair).and_return('Test')
       expect(provider.repair).to be
     end
 
     it 'should be able to get the attachable volumes' do
-      allow(resourcetype).to receive(:get_attachable_volumes).with(anything).and_return('Test')
+      allow(resource_type).to receive(:get_attachable_volumes).with(anything).and_return('Test')
       expect(provider.get_attachable_volumes).to be
     end
 
     it 'should be able to get the extra managed volume paths' do
-      allow(resourcetype).to receive(:get_extra_managed_volume_paths).with(anything).and_return('Test')
+      allow(resource_type).to receive(:get_extra_managed_volume_paths).with(anything).and_return('Test')
       expect(provider.get_extra_managed_volume_paths).to be
     end
 
     it 'should delete the snapshot' do
       resource['data']['snapshotParameters'] = { 'name' => 'Snapshot' }
-      allow_any_instance_of(resourcetype).to receive(:delete_snapshot).with(resource['data']['snapshotParameters']['name'])
+      allow_any_instance_of(resource_type).to receive(:delete_snapshot).with(resource['data']['snapshotParameters']['name'])
         .and_return('Test')
       expect(provider.delete_snapshot).to be
     end
 
     it 'should create the snapshot' do
       resource['data']['snapshotParameters'] = { 'name' => 'Snapshot' }
-      allow_any_instance_of(resourcetype).to receive(:create_snapshot).with('name' => resource['data']['snapshotParameters']['name'])
+      allow_any_instance_of(resource_type).to receive(:create_snapshot).with('name' => resource['data']['snapshotParameters']['name'])
         .and_return('Test')
       expect(provider.create_snapshot).to be
     end

--- a/spec/unit/provider/oneview_volume_template_c7000_spec.rb
+++ b/spec/unit/provider/oneview_volume_template_c7000_spec.rb
@@ -22,7 +22,7 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:VolumeTemplate, api_version, 'C7000')
+  resource_type = OneviewSDK.resource_named(:VolumeTemplate, api_version, 'C7000')
 
   let(:resource) do
     Puppet::Type.type(:oneview_volume_template).new(
@@ -49,11 +49,11 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the Creation parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -62,19 +62,19 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'if nothing is found should return false' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to find the connectable volume templates' do
-      allow_any_instance_of(resourcetype).to receive(:get_connectable_volume_templates).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:get_connectable_volume_templates).and_return(true)
       expect(provider.get_connectable_volume_templates).to be
     end
   end

--- a/spec/unit/provider/oneview_volume_template_c7000_spec.rb
+++ b/spec/unit/provider/oneview_volume_template_c7000_spec.rb
@@ -18,11 +18,10 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_volume_template).provider(:c7000)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:VolumeTemplate, api_version, :C7000)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true do
   include_context 'shared context'
-
-  resource_type = OneviewSDK.resource_named(:VolumeTemplate, api_version, 'C7000')
 
   let(:resource) do
     Puppet::Type.type(:oneview_volume_template).new(

--- a/spec/unit/provider/oneview_volume_template_synergy_spec.rb
+++ b/spec/unit/provider/oneview_volume_template_synergy_spec.rb
@@ -22,9 +22,9 @@ api_version = login[:api_version] || 200
 describe provider_class, unit: true, if: login[:api_version] >= 300 do
   include_context 'shared context'
 
-  resourcetype = OneviewSDK.resource_named(:VolumeTemplate, api_version, 'Synergy')
+  resource_type = OneviewSDK.resource_named(:VolumeTemplate, api_version, 'Synergy')
 
-  @resourcetype = resourcetype
+  @resource_type = resource_type
   let(:resource) do
     Puppet::Type.type(:oneview_volume_template).new(
       name: 'vt',
@@ -50,11 +50,11 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
 
   let(:instance) { provider.class.instances.first }
 
-  let(:test) { resourcetype.new(@client, resource['data']) }
+  let(:test) { resource_type.new(@client, resource['data']) }
 
   context 'given the Creation parameters' do
     before(:each) do
-      allow(resourcetype).to receive(:find_by).and_return([test])
+      allow(resource_type).to receive(:find_by).and_return([test])
       provider.exists?
     end
 
@@ -63,19 +63,19 @@ describe provider_class, unit: true, if: login[:api_version] >= 300 do
     end
 
     it 'if nothing is found should return false' do
-      allow(resourcetype).to receive(:find_by).and_return([])
+      allow(resource_type).to receive(:find_by).and_return([])
       expect(provider.exists?).to eq(false)
     end
 
     it 'runs through the create method' do
-      allow(resourcetype).to receive(:find_by).and_return([])
-      allow_any_instance_of(resourcetype).to receive(:create).and_return(test)
+      allow(resource_type).to receive(:find_by).and_return([])
+      allow_any_instance_of(resource_type).to receive(:create).and_return(test)
       provider.exists?
       expect(provider.create).to be
     end
 
     it 'should be able to find the connectable volume templates' do
-      allow_any_instance_of(resourcetype).to receive(:get_connectable_volume_templates).and_return(true)
+      allow_any_instance_of(resource_type).to receive(:get_connectable_volume_templates).and_return(true)
       expect(provider.get_connectable_volume_templates).to be
     end
   end

--- a/spec/unit/provider/oneview_volume_template_synergy_spec.rb
+++ b/spec/unit/provider/oneview_volume_template_synergy_spec.rb
@@ -18,13 +18,11 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:oneview_volume_template).provider(:synergy)
 api_version = login[:api_version] || 200
+resource_type = OneviewSDK.resource_named(:VolumeTemplate, api_version, :Synergy)
 
-describe provider_class, unit: true, if: login[:api_version] >= 300 do
+describe provider_class, unit: true, if: api_version >= 300 do
   include_context 'shared context'
 
-  resource_type = OneviewSDK.resource_named(:VolumeTemplate, api_version, 'Synergy')
-
-  @resource_type = resource_type
   let(:resource) do
     Puppet::Type.type(:oneview_volume_template).new(
       name: 'vt',


### PR DESCRIPTION
### Description
This PR improves our idempotency in regards to server profiles and server profile templates. 
When using nested hashes before, the resource would run updates even when nothing had been updated. 
With this change, hopefully we will just be running things when needed be. 

To achieve such idempotency, this PR includes a major refactor to the `resource_update` method which is used by most resources, and a few changes to the `exists?` method of SP and SPT resources. 
These changes in the resources make the idempotency a lot more viable and should be added to the `oneview_resource`'s  `exists?` method in order to be cascaded to every single resource.
However, since this will generate a lot of changes as well and make review worse, I'm leaving that for a separate/future PR.

### Issues Resolved
#95 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
