### PR TITLE
Fix: Logical Interconnect Group get_default_settings method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - [#122](https://github.com/HewlettPackard/oneview-puppet/issues/122) Uri_parsing should support upper case for uri
 - [#133](https://github.com/HewlettPackard/oneview-puppet/issues/133) Allow set a timeout for Image_streamer_golden_image upload
 - [#132](https://github.com/HewlettPackard/oneview-puppet/issues/132) Allow option force for Image_streamer_golden_image download operations
-- [#139](https://github.com/HewlettPackard/oneview-puppet/issues/139) Error running get_default_settings (Logical Interconnect Group/Synergy)
+- [#139](https://github.com/HewlettPackard/oneview-puppet/issues/139) Error running oneview_logical_interconnect's ensure method get_default_settings after upgrading OneView SDK to >= v4.1
 
 # 2.1.0 (2017-02-03)
 ### Version highlights:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#122](https://github.com/HewlettPackard/oneview-puppet/issues/122) Uri_parsing should support upper case for uri
 - [#133](https://github.com/HewlettPackard/oneview-puppet/issues/133) Allow set a timeout for Image_streamer_golden_image upload
 - [#132](https://github.com/HewlettPackard/oneview-puppet/issues/132) Allow option force for Image_streamer_golden_image download operations
+- [#139](https://github.com/HewlettPackard/oneview-puppet/issues/139) Error running get_default_settings (Logical Interconnect Group/Synergy)
 
 # 2.1.0 (2017-02-03)
 ### Version highlights:

--- a/lib/puppet/provider/oneview_logical_interconnect_group/synergy.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/synergy.rb
@@ -26,10 +26,4 @@ Puppet::Type.type(:oneview_logical_interconnect_group).provide :synergy, parent:
     end
     lig['interconnectMapTemplate']
   end
-
-  def get_default_settings
-    Puppet.notice("\n\nLogical Interconnect Group Default Settings\n")
-    pretty @resourcetype.get_default_settings
-    true
-  end
 end


### PR DESCRIPTION
### Description
Fixes get_default_settings error which occurs using hardware variant Synergy.

### Issues Resolved
#139 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
