### PR TITLE
Prepare for v2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased Changes
 
-## Suggested release: v2.2.0
+
+# 2.2.0 (2017-03-28)
 ### Version highlights:
 1. Added support to the Image Streamer REST API version 300 for OS provisioning through OneView.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-# Unreleased Changes
-
-
 # 2.2.0 (2017-03-28)
 ### Version highlights:
 1. Added support to the Image Streamer REST API version 300 for OS provisioning through OneView.

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source 'http://rubygems.org'
 gem 'coveralls', require: false
 gem 'facter', '>= 1.7.0'
 gem 'metadata-json-lint'
-# NOTE: Enable the line bellow and disable the oneview-sdk line if you want to use the most updated version of the
-# oneview-sdk or unreleased resources. This might lead to bugs.
-# gem 'oneview-sdk', git: 'https://github.com/HewlettPackard/oneview-sdk-ruby.git', branch: 'master'
 gem 'oneview-sdk', '~> 4.2'
 gem 'pry'
 gem 'puppet', '>= 4.1'

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,10 @@ source 'http://rubygems.org'
 gem 'coveralls', require: false
 gem 'facter', '>= 1.7.0'
 gem 'metadata-json-lint'
-# TODO: Remove the oneview-sdk line using github and reenable the one using oneview-sdk (with corrected version) BEFORE the release
-# gem 'oneview-sdk', '~> 3.1'
-gem 'oneview-sdk', git: 'https://github.com/HewlettPackard/oneview-sdk-ruby.git', branch: 'master'
+# NOTE: Enable the line bellow and disable the oneview-sdk line if you want to use the most updated version of the
+# oneview-sdk or unreleased resources. This might lead to bugs.
+# gem 'oneview-sdk', git: 'https://github.com/HewlettPackard/oneview-sdk-ruby.git', branch: 'master'
+gem 'oneview-sdk', '~> 4.2'
 gem 'pry'
 gem 'puppet', '>= 4.1'
 gem 'puppet-lint', '>= 0.3.2'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![Puppet Forge](https://img.shields.io/puppetforge/v/hewlettpackard/oneview.svg)](https://forge.puppet.com/hewlettpackard/oneview)
+[![Inline docs](http://inch-ci.org/github/HewlettPackard/oneview-puppet.svg?branch=master)](http://inch-ci.org/github/HewlettPackard/oneview-puppet)
 [![Build Status](https://travis-ci.org/HewlettPackard/oneview-puppet.svg?branch=master)](https://travis-ci.org/HewlettPackard/oneview-puppet)
 [![Coverage Status](https://coveralls.io/repos/github/HewlettPackard/oneview-puppet/badge.svg?branch=master)](https://coveralls.io/github/HewlettPackard/oneview-puppet?branch=master)
-[![Inline docs](http://inch-ci.org/github/HewlettPackard/oneview-puppet.svg?branch=master)](http://inch-ci.org/github/HewlettPackard/oneview-puppet)
+[![Code Climate](https://codeclimate.com/github/HewlettPackard/oneview-puppet/badges/gpa.svg)](https://codeclimate.com/github/HewlettPackard/oneview-puppet)
 
 # Puppet Module for HPE OneView
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hewlettpackard-oneview",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "Hewlett Packard Enterprise",
   "summary": "HPE Puppet providers and types for management of HPE OneView Appliances",
   "license": "Apache-2.0",
@@ -34,7 +34,7 @@
   "requirements": [
     {"name":"puppet","version_requirement":">= 4.1.0"},
     {"name": "ruby","version_requirement": ">=2.2.3"},
-    {"name": "oneview-sdk-ruby","version_requirement": ">=3.1.0"}
+    {"name": "oneview-sdk-ruby","version_requirement": ">=4.2.0"}
   ],
   "tags": [ "oneview", "hpe", "hewlett packard enterprise", "i3s", "image streamer", "bare-metal provisioning" ],
   "data_provider": null


### PR DESCRIPTION
### Description
Updating metadata, gemfile and docs to prepare for release of v2.2.0 of the module

### Issues Resolved
For the full list of issues resolved with this release, verify the [Changelog](https://github.com/HewlettPackard/oneview-puppet/blob/3626a36b5ffaf9d0e6f11cc2ed7cac4e8931329e/CHANGELOG.md)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
