### PR TITLE
Server profile creation returns `The network does not exist in the Appliance.` even when network exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#95](https://github.com/HewlettPackard/oneview-puppet/issues/95) Improve server profile idempotency
 - [#101](https://github.com/HewlettPackard/oneview-puppet/issues/101) Improve server profile template idempotency
 - [#145](https://github.com/HewlettPackard/oneview-puppet/issues/145) Refactor oneview_resource class and common for v2.2.0
+- [#149](https://github.com/HewlettPackard/oneview-puppet/issues/149) Server Profile - Network uris set inside the connections return error
 
 # 2.2.0 (2017-03-28)
 ### Version highlights:

--- a/lib/puppet/provider/common.rb
+++ b/lib/puppet/provider/common.rb
@@ -115,7 +115,7 @@ end
 # FCoE to be added (no need so far)
 def connections_parse
   @data['connections'].each do |conn|
-    next if conn['uri'].to_s[0..6].include?('/rest/')
+    next if conn['networkUri'].to_s[0..6].include?('/rest/')
     type = case conn['functionType']
            when 'Ethernet' then 'EthernetNetwork'
            when 'FibreChannel' then 'FCNetwork'
@@ -124,7 +124,7 @@ def connections_parse
              'NetworkSet'
            end
     net = objectfromstring(type).find_by(@client, name: conn['networkUri'])
-    raise('The network does not exist in the Appliance.') unless net.first
+    raise("The network #{conn['networkUri']} does not exist in the Appliance.") unless net.first
     conn['networkUri'] = net.first['uri']
   end
 end


### PR DESCRIPTION
### Description
Fixes issue where connections tries to retrieve a network and fails even when the network uri is already specified

### Issues Resolved
#149 

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
