### PR TITLE
SAS resource automatic name to uri convertion fails in manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Suggested release: v2.2.1
 ### Version highlights:
-1. Major refactor on internal methods. Improved idempotency and logging project-wide and reduced lines of code count.
+1. Major refactor on internal methods. Improved idempotency, logging project-wide and reduced lines of code count.
 
 #### Bug fixes & Enhancements:
 - [#95](https://github.com/HewlettPackard/oneview-puppet/issues/95) Improve server profile idempotency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#101](https://github.com/HewlettPackard/oneview-puppet/issues/101) Improve server profile template idempotency
 - [#145](https://github.com/HewlettPackard/oneview-puppet/issues/145) Refactor oneview_resource class and common for v2.2.0
 - [#149](https://github.com/HewlettPackard/oneview-puppet/issues/149) Server Profile - Network uris set inside the connections return error
+- [#151](https://github.com/HewlettPackard/oneview-puppet/issues/151) SAS Logical Interconnect Group - Name to URI conversion fails on logicalInterconnectGroupUri fields
 
 # 2.2.0 (2017-03-28)
 ### Version highlights:

--- a/lib/puppet/provider/uri_parsing.rb
+++ b/lib/puppet/provider/uri_parsing.rb
@@ -45,8 +45,9 @@ end
 def get_uri(key)
   ov_class = get_class(special_resources_check(key))
   ov_resource = ov_class.find_by(@client, name: @value)
-  if sas_lig_check(ov_resource, ov_class)
-    ov_resource = OneviewSDK.resource_named(:SASLogicalInterconnectGroup, login[:api_version], :Synergy).find_by(@client, name: @value)
+  if sas_resources_check(ov_resource, ov_class)
+    ov_class = ov_class.to_s.split('::')[-1]
+    ov_resource = OneviewSDK.resource_named("SAS#{ov_class}", login[:api_version], :Synergy).find_by(@client, name: @value)
   end
   # fails if ov_resource returns an empty hash (no results)
   raise "'#{@value}' has not been found in the Appliance." if ov_resource.empty?
@@ -116,7 +117,8 @@ def get_class(key)
   Object.const_get("OneviewSDK::#{sub_module}API#{@client.api_version}::#{variant}#{resource_name}")
 end
 
-# Used for handling LIG uris which refer to SAS LIG resources
-def sas_lig_check(ov_resource, ov_class)
-  ov_resource.empty? && ov_class.to_s.split('::')[-1] == 'LogicalInterconnectGroup' && resource_variant.to_sym == :Synergy
+# Used for handling uris that refer to SAS resources
+def sas_resources_check(ov_resource, ov_class)
+  return false unless %w(LogicalInterconnectGroup LogicalInterconnect Interconnect).include?(ov_class.to_s.split('::')[-1])
+  ov_resource.empty? && resource_variant.to_sym == :Synergy
 end

--- a/lib/puppet/provider/uri_parsing.rb
+++ b/lib/puppet/provider/uri_parsing.rb
@@ -43,13 +43,15 @@ end
 
 # Gets the Uri for the resource
 def get_uri(key)
-  parsed_key = special_resources_check(key)
-  # looks for the resource
-  resource = get_class(parsed_key).find_by(@client, name: @value)
-  # fails if resource returns an empty hash (no results)
-  raise "'#{@value}' has not been found in the Appliance." if resource.empty?
+  ov_class = get_class(special_resources_check(key))
+  ov_resource = ov_class.find_by(@client, name: @value)
+  if sas_lig_check(ov_resource, ov_class)
+    ov_resource = OneviewSDK.resource_named(:SASLogicalInterconnectGroup, login[:api_version], :Synergy).find_by(@client, name: @value)
+  end
+  # fails if ov_resource returns an empty hash (no results)
+  raise "'#{@value}' has not been found in the Appliance." if ov_resource.empty?
   # replaces the parameter name by its uri
-  resource.first.data['uri']
+  ov_resource.first.data['uri']
 end
 
 # Check for special/exceptions to the uri default search
@@ -112,4 +114,9 @@ def get_class(key)
   variant = OneviewSDK::Client == @client.class && @client.api_version > 200 ? "#{resource_variant}::" : ''
   resource_name = "#{key.to_s[0].upcase}#{key[1..key.size - 4]}"
   Object.const_get("OneviewSDK::#{sub_module}API#{@client.api_version}::#{variant}#{resource_name}")
+end
+
+# Used for handling LIG uris which refer to SAS LIG resources
+def sas_lig_check(ov_resource, ov_class)
+  ov_resource.empty? && ov_class.to_s.split('::')[-1] == 'LogicalInterconnectGroup' && resource_variant.to_sym == :Synergy
 end


### PR DESCRIPTION
### Description
Fixes issue where SAS resources uris are not retrieved when passing in a name in a uri field.

### Issues Resolved
#151 

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
