### PR TITLE
Improved idempotency for firmware bundle uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#145](https://github.com/HewlettPackard/oneview-puppet/issues/145) Refactor oneview_resource class and common for v2.2.0
 - [#149](https://github.com/HewlettPackard/oneview-puppet/issues/149) Server Profile - Network uris set inside the connections return error
 - [#151](https://github.com/HewlettPackard/oneview-puppet/issues/151) SAS Logical Interconnect Group - Name to URI conversion fails on logicalInterconnectGroupUri fields
+- [#153](https://github.com/HewlettPackard/oneview-puppet/issues/153) Idempotence error: Running a ensure => 'present' on a oneview_firmware_bundle resource
 
 # 2.2.0 (2017-03-28)
 ### Version highlights:

--- a/examples/firmware_bundle.pp
+++ b/examples/firmware_bundle.pp
@@ -19,6 +19,7 @@
 oneview_firmware_bundle{'firmware_bundle_1':
     ensure => 'present',
     data   => {
-      firmware_bundle_path => './spec/support/cp022594.exe'
+      # firmware_bundle_path => './spec/support/cp022594.exe'
+      firmware_bundle_path => 'E:\cp020307.exe' # For Puppet on windows use Windows Pathing
     },
 }

--- a/lib/puppet/provider/oneview_firmware_bundle/c7000.rb
+++ b/lib/puppet/provider/oneview_firmware_bundle/c7000.rb
@@ -31,6 +31,9 @@ Puppet::Type.type(:oneview_firmware_bundle).provide :c7000, parent: Puppet::Onev
   def exists?
     prepare_environment
     raise 'A "firmware_bundle_path" is required for this operation' unless @data['firmware_bundle_path']
+    filename = File.basename(@data['firmware_bundle_path'], File.extname(@data['firmware_bundle_path'])).tr('.', '_')
+    firmware_list = OneviewSDK.resource_named(:FirmwareDriver, @client.api_version, resource_variant).get_all(@client)
+    firmware_list.find { |fw| filename == fw['resourceId'] }
   end
 
   def create


### PR DESCRIPTION
### Description
Adds a validation using the name of the file being uploaded against the resourceId of all firmwares present in the appliance, in order to detect if a file has been uploaded already or not.

### Issues Resolved
#153 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
