### PR TITLE
Support compact syntax for Q ports in Synergy LIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## Suggested release: v2.2.1
 ### Version highlights:
 1. Major refactor on internal methods. Improved idempotency, logging project-wide and reduced lines of code count.
+2. Raised 'oneview-sdk' version used to ~ 4.4.X.
+3. Many bugfixes and improvements.
 
 #### Bug fixes & Enhancements:
 - [#95](https://github.com/HewlettPackard/oneview-puppet/issues/95) Improve server profile idempotency
 - [#101](https://github.com/HewlettPackard/oneview-puppet/issues/101) Improve server profile template idempotency
 - [#145](https://github.com/HewlettPackard/oneview-puppet/issues/145) Refactor oneview_resource class and common for v2.2.0
+- [#148](https://github.com/HewlettPackard/oneview-puppet/issues/148) Cannot create uplinkset for LIG on a Synergy frame
 - [#149](https://github.com/HewlettPackard/oneview-puppet/issues/149) Server Profile - Network uris set inside the connections return error
 - [#151](https://github.com/HewlettPackard/oneview-puppet/issues/151) SAS Logical Interconnect Group - Name to URI conversion fails on logicalInterconnectGroupUri fields
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v2.2.1
+# v2.2.1 (2017-05-22)
 ### Version highlights:
 1. Major refactor on internal methods. Improved idempotency, logging project-wide and reduced lines of code count.
 2. Raised 'oneview-sdk' version used to ~> 4.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v2.2.1
 ### Version highlights:
 1. Major refactor on internal methods. Improved idempotency, logging project-wide and reduced lines of code count.
-2. Raised 'oneview-sdk' version used to ~4.4.
+2. Raised 'oneview-sdk' version used to ~> 4.4.
 3. Several bugfixes and improvements.
 
 #### Bug fixes & Enhancements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
-# Unreleased Changes
-
-## Suggested release: v2.2.1
+# v2.2.1
 ### Version highlights:
 1. Major refactor on internal methods. Improved idempotency, logging project-wide and reduced lines of code count.
-2. Raised 'oneview-sdk' version used to ~ 4.4.X.
-3. Many bugfixes and improvements.
+2. Raised 'oneview-sdk' version used to ~4.4.
+3. Several bugfixes and improvements.
 
 #### Bug fixes & Enhancements:
 - [#95](https://github.com/HewlettPackard/oneview-puppet/issues/95) Improve server profile idempotency

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org'
 gem 'coveralls', require: false
 gem 'facter', '>= 1.7.0'
 gem 'metadata-json-lint'
-gem 'oneview-sdk', '~> 4.2'
+gem 'oneview-sdk', '~> 4.4'
 gem 'pry'
 gem 'puppet', '>= 4.1'
 gem 'puppet-lint', '>= 0.3.2'

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For more information on the Puppet Module for HPE OneView resource types and the
 ### Requirements
 
   - Puppet V4.1 or greater
-  - Ruby V2.2.3 or greater
+  - Ruby V4.4.0 or greater
   - [oneview-sdk-ruby](https://github.com/HewlettPackard/oneview-sdk-ruby) V3.1.0 or greater (available as a gem)
 
 ### Beginning with the Puppet Module for HPE OneView

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For more information on the Puppet Module for HPE OneView resource types and the
 ### Requirements
 
   - Puppet V4.1 or greater
-  - Ruby V4.4.0 or greater
+  - Ruby V2.2.3 or greater
   - [oneview-sdk-ruby](https://github.com/HewlettPackard/oneview-sdk-ruby) V3.1.0 or greater (available as a gem)
 
 ### Beginning with the Puppet Module for HPE OneView

--- a/examples/logical_interconnect_group_synergy.pp
+++ b/examples/logical_interconnect_group_synergy.pp
@@ -14,23 +14,61 @@
 # limitations under the License.
 ################################################################################
 
-# The Interconnects and Uplink Sets can also be declared as follows:
-oneview_logical_interconnect_group{'Puppet Ethernet LIG Synergy':
+# This sample creates a complex LIG with an Uplink and Interconnect using 2 enclosures.
+# If no enclosure_index is provided for interconnects, a value of '1' is assumed.
+$interconnect_type_1 = 'Virtual Connect SE 40Gb F8 Module for Synergy'
+$interconnect_type_2 = 'Synergy 20Gb Interconnect Link Module'
+$network_names = [ 'tunnelnet1' ]
+oneview_logical_interconnect_group{'Puppet - Synergy Tunnel LIG with 2 Enclosures':
   ensure => 'present',
   data   => {
-    name               => 'Puppet Ethernet LIG Synergy',
-    redundancyType     => 'Redundant',
+    name               => 'Puppet - Synergy Tunnel LIG with 2 Enclosures',
+    redundancyType     => 'HighlyAvailable',
     interconnectBaySet => 3,
+    enclosureType      => 'SY12000',
+    enclosureIndexes   => [1, 2],
+    uplinkSets         =>
+    [
+      {
+        name                => 'TUNNEL_ETH_UP_01',
+        ethernetNetworkType => 'Tunnel',
+        networkType         => 'Ethernet',
+        lacpTimer           => 'Short',
+        mode                => 'Auto',
+        uplink_ports        => [{ bay             => 3,
+                                  port            => 'Q1',
+                                  type            => $interconnect_type_1,
+                                  enclosure_index => 1 },
+                                { bay             => 6,
+                                  port            => 'Q1',
+                                  type            => $interconnect_type_1,
+                                  enclosure_index => 2 }
+        ],
+        networkUris         => $network_names
+      }
+    ],
     interconnects      =>
     [
       {
-        bay  => 3,
-        type => 'Virtual Connect SE 40Gb F8 Module for Synergy'
+        bay             => 3,
+        type            => $interconnect_type_1,
+        enclosure_index => 1
       },
       {
-        bay  => 6,
-        type => 'Virtual Connect SE 40Gb F8 Module for Synergy'
+        bay             => 6,
+        type            => $interconnect_type_1,
+        enclosure_index => 2
       },
+      {
+        bay             => 3,
+        type            => $interconnect_type_2,
+        enclosure_index => 2
+      },
+      {
+        bay             => 6,
+        type            => $interconnect_type_2,
+        enclosure_index => 1
+      }
     ]
   }
 }
@@ -48,12 +86,14 @@ oneview_logical_interconnect_group{'Puppet FC LIG Synergy':
     interconnects      =>
     [
       {
-        bay  => 1,
-        type => 'Virtual Connect SE 16Gb FC Module for Synergy'
+        bay             => 1,
+        type            => 'Virtual Connect SE 16Gb FC Module for Synergy',
+        enclosure_index => -1
       },
       {
-        bay  => 4,
-        type => 'Virtual Connect SE 16Gb FC Module for Synergy'
+        bay             => 4,
+        type            => 'Virtual Connect SE 16Gb FC Module for Synergy',
+        enclosure_index => -1
       },
     ]
   }
@@ -61,9 +101,9 @@ oneview_logical_interconnect_group{'Puppet FC LIG Synergy':
 
 oneview_logical_interconnect_group{'Logical Interconnect Group Edit':
   ensure  => 'present',
-  require => Oneview_logical_interconnect_group['Puppet Ethernet LIG Synergy'],
+  require => Oneview_logical_interconnect_group['Puppet - Synergy Tunnel LIG with 2 Enclosures'],
   data    => {
-    name     => 'Puppet Ethernet LIG Synergy',
+    name     => 'Puppet - Synergy Tunnel LIG with 2 Enclosures',
     new_name => 'Edited LIG'
   }
 }

--- a/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
@@ -119,7 +119,8 @@ Puppet::Type.type(:oneview_logical_interconnect_group).provide :c7000, parent: P
   # Method to add the uplink bay & port to the LIGuplinkSet using helpers
   def set_uplink_ports(uplink_set, uplink_ports)
     uplink_ports.each do |uplink_port|
-      uplink_set.add_uplink(uplink_port['bay'], uplink_port['port'])
+      uplink_port['enclosure_index'] ||= 1
+      uplink_set.add_uplink(uplink_port['bay'], uplink_port['port'], uplink_port['type'], uplink_port['enclosure_index'])
     end
     uplink_set
   end

--- a/lib/puppet/provider/oneview_logical_interconnect_group/synergy.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/synergy.rb
@@ -22,6 +22,7 @@ Puppet::Type.type(:oneview_logical_interconnect_group).provide :synergy, parent:
   def parse_interconnects
     lig = OneviewSDK.resource_named(:LogicalInterconnectGroup, login[:api_version], 'Synergy').new(@client, {})
     @interconnects.each do |item|
+      item['enclosure_index'] ||= 1
       lig.add_interconnect(item['bay'].to_i, item['type'], item['logical_downlink'], item['enclosure_index'])
     end
     lig['interconnectMapTemplate']

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hewlettpackard-oneview",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Hewlett Packard Enterprise",
   "summary": "HPE Puppet providers and types for management of HPE OneView Appliances",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
   "requirements": [
     {"name":"puppet","version_requirement":">= 4.1.0"},
     {"name": "ruby","version_requirement": ">=2.2.3"},
-    {"name": "oneview-sdk-ruby","version_requirement": ">=4.2.0"}
+    {"name": "oneview-sdk-ruby","version_requirement": ">=4.4.0"}
   ],
   "tags": [ "oneview", "hpe", "hewlett packard enterprise", "i3s", "image streamer", "bare-metal provisioning" ],
   "data_provider": null


### PR DESCRIPTION
### Description
This PR improves the LIG synergy example and allows the use of the compact syntax for uplink sets creation on synergy

### Issues Resolved
#148 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
