### PR TITLE
Add :oneview feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # v2.2.2 # UNRELEASED CHANGES
 ### Version highlights:
 1. Provider names are now case insensitive
+2. Added the 'oneview' feature
 
 #### Bug fixes & Enhancements:
 - [#159](https://github.com/HewlettPackard/oneview-puppet/issues/159) Provider name should not be case sensitive
+- [#161](https://github.com/HewlettPackard/oneview-puppet/issues/161) Add rescue to requirement of 'oneview-sdk' to avoid catalog issues
 
 # v2.2.1 (2017-05-22)
 ### Version highlights:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v2.2.2 # UNRELEASED CHANGES
 ### Version highlights:
 1. Provider names are now case insensitive
-2. Added the 'oneview' feature
+2. Added the 'oneview' Puppet feature to require the 'oneview-sdk'
 
 #### Bug fixes & Enhancements:
 - [#159](https://github.com/HewlettPackard/oneview-puppet/issues/159) Provider name should not be case sensitive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v2.2.2 # UNRELEASED CHANGES
+# v2.2.2 (2017-07-07)
 ### Version highlights:
 1. Provider names are now case insensitive
 2. Added the 'oneview' Puppet feature to require the 'oneview-sdk'

--- a/lib/puppet/feature/oneview.rb
+++ b/lib/puppet/feature/oneview.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:oneview, libs: ['oneview-sdk'])

--- a/lib/puppet/provider/image_streamer_artifact_bundle/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_artifact_bundle/image_streamer.rb
@@ -19,6 +19,8 @@ require_relative '../image_streamer_resource'
 Puppet::Type.type(:image_streamer_artifact_bundle).provide :image_streamer, parent: Puppet::ImageStreamerResource do
   desc 'Provider for Image Streamer Artifact Bundles using the Image Streamer API'
 
+  confine feature: :oneview
+
   mk_resource_methods
 
   def exists?

--- a/lib/puppet/provider/image_streamer_build_plan/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_build_plan/image_streamer.rb
@@ -19,5 +19,7 @@ require_relative '../image_streamer_resource'
 Puppet::Type.type(:image_streamer_build_plan).provide :image_streamer, parent: Puppet::ImageStreamerResource do
   desc 'Provider for Image Streamer Build Plan using the Image Streamer API'
 
+  confine feature: :oneview
+
   mk_resource_methods
 end

--- a/lib/puppet/provider/image_streamer_deployment_group/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_deployment_group/image_streamer.rb
@@ -19,5 +19,7 @@ require_relative '../image_streamer_resource'
 Puppet::Type.type(:image_streamer_deployment_group).provide :image_streamer, parent: Puppet::ImageStreamerResource do
   desc 'Provider for Image Streamer Deployment Groups using the Image Streamer API'
 
+  confine feature: :oneview
+
   mk_resource_methods
 end

--- a/lib/puppet/provider/image_streamer_deployment_plan/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_deployment_plan/image_streamer.rb
@@ -19,5 +19,7 @@ require_relative '../image_streamer_resource'
 Puppet::Type.type(:image_streamer_deployment_plan).provide :image_streamer, parent: Puppet::ImageStreamerResource do
   desc 'Provider for Image Streamer Deployment Plan using the Image Streamer API'
 
+  confine feature: :oneview
+
   mk_resource_methods
 end

--- a/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_golden_image/image_streamer.rb
@@ -19,6 +19,8 @@ require_relative '../image_streamer_resource'
 Puppet::Type::Image_streamer_golden_image.provide :image_streamer, parent: Puppet::ImageStreamerResource do
   desc 'Provider for Image Streamer Golden Image using the Image Streamer API'
 
+  confine feature: :oneview
+
   mk_resource_methods
 
   def data_parse

--- a/lib/puppet/provider/image_streamer_os_volume/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_os_volume/image_streamer.rb
@@ -19,6 +19,8 @@ require_relative '../image_streamer_resource'
 Puppet::Type.type(:image_streamer_os_volume).provide :image_streamer, parent: Puppet::ImageStreamerResource do
   desc 'Provider for Image Streamer OS Volumes using the Image Streamer API'
 
+  confine feature: :oneview
+
   mk_resource_methods
 
   def get_details_archive

--- a/lib/puppet/provider/image_streamer_plan_script/image_streamer.rb
+++ b/lib/puppet/provider/image_streamer_plan_script/image_streamer.rb
@@ -19,6 +19,8 @@ require_relative '../image_streamer_resource'
 Puppet::Type.type(:image_streamer_plan_script).provide :image_streamer, parent: Puppet::ImageStreamerResource do
   desc 'Provider for Image Streamer Plan Scripts using the Image Streamer API'
 
+  confine feature: :oneview
+
   mk_resource_methods
 
   def retrieve_differences

--- a/lib/puppet/provider/oneview_connection_template/c7000.rb
+++ b/lib/puppet/provider/oneview_connection_template/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_connection_template).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Connection Templates using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_connection_template/synergy.rb
+++ b/lib/puppet/provider/oneview_connection_template/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_connection_template).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Connection Templates using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_datacenter/c7000.rb
+++ b/lib/puppet/provider/oneview_datacenter/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_datacenter).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Datacenters using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_datacenter/synergy.rb
+++ b/lib/puppet/provider/oneview_datacenter/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_datacenter).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Datacenters using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_drive_enclosure/synergy.rb
+++ b/lib/puppet/provider/oneview_drive_enclosure/synergy.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_drive_enclosure).provide :synergy, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Drive Enclosures using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_enclosure/c7000.rb
+++ b/lib/puppet/provider/oneview_enclosure/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_enclosure).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Enclosures using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_enclosure/synergy.rb
+++ b/lib/puppet/provider/oneview_enclosure/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_enclosure).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Enclosures using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_enclosure_group/c7000.rb
+++ b/lib/puppet/provider/oneview_enclosure_group/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_enclosure_group).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Enclosure Groups using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_enclosure_group/synergy.rb
+++ b/lib/puppet/provider/oneview_enclosure_group/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_enclosure_group).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Enclosure Groups using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_ethernet_network/c7000.rb
+++ b/lib/puppet/provider/oneview_ethernet_network/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_ethernet_network).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Ethernet Networks using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_ethernet_network/synergy.rb
+++ b/lib/puppet/provider/oneview_ethernet_network/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_ethernet_network).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Ethernet Networks using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_fabric/c7000.rb
+++ b/lib/puppet/provider/oneview_fabric/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_fabric).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Fabrics using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_fabric/synergy.rb
+++ b/lib/puppet/provider/oneview_fabric/synergy.rb
@@ -17,6 +17,7 @@
 Puppet::Type.type(:oneview_fabric).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Fabrics using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 
   def get_reserved_vlan_range

--- a/lib/puppet/provider/oneview_fc_network/c7000.rb
+++ b/lib/puppet/provider/oneview_fc_network/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_fc_network).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Fiber Channel Networks using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_fc_network/synergy.rb
+++ b/lib/puppet/provider/oneview_fc_network/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_fc_network).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Fiber Channel Networks using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_fcoe_network/c7000.rb
+++ b/lib/puppet/provider/oneview_fcoe_network/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_fcoe_network).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Fiber Channel over Ethernet Networks using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_fcoe_network/synergy.rb
+++ b/lib/puppet/provider/oneview_fcoe_network/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_fcoe_network).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Fiber Channel over Ethernet Networks using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_firmware_bundle/c7000.rb
+++ b/lib/puppet/provider/oneview_firmware_bundle/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_firmware_bundle).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Firmware Bundles using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_firmware_bundle/synergy.rb
+++ b/lib/puppet/provider/oneview_firmware_bundle/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_firmware_bundle).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Firmware Bundles using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_firmware_driver/c7000.rb
+++ b/lib/puppet/provider/oneview_firmware_driver/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_firmware_driver).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Firmware Drivers using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_firmware_driver/synergy.rb
+++ b/lib/puppet/provider/oneview_firmware_driver/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_firmware_driver).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Firmware Drivers using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_interconnect/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_interconnect).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Interconnects using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_interconnect/synergy.rb
@@ -17,6 +17,7 @@
 Puppet::Type.type(:oneview_interconnect).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Interconnects using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
   defaultfor oneview_synergy_variant: 'Synergy'
 

--- a/lib/puppet/provider/oneview_logical_downlink/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_downlink/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_logical_downlink).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Logical Downlinks using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_logical_downlink/synergy.rb
+++ b/lib/puppet/provider/oneview_logical_downlink/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_logical_downlink).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Logical Downlinks using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_logical_enclosure/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_enclosure/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_logical_enclosure).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Logical Enclosures using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_logical_enclosure/synergy.rb
+++ b/lib/puppet/provider/oneview_logical_enclosure/synergy.rb
@@ -17,6 +17,7 @@
 Puppet::Type.type(:oneview_logical_enclosure).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Logical Enclosures using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 
   def set_script

--- a/lib/puppet/provider/oneview_logical_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_logical_interconnect).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Logical Interconnects using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_logical_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_logical_interconnect).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Logical Interconnects using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_logical_interconnect_group).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Logical Enclosures using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_logical_interconnect_group/synergy.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect_group/synergy.rb
@@ -17,6 +17,7 @@
 Puppet::Type.type(:oneview_logical_interconnect_group).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Fiber Channel Networks using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 
   def parse_interconnects

--- a/lib/puppet/provider/oneview_logical_switch/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_switch/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_logical_switch).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Logical Switches using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_logical_switch_group/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_switch_group/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_logical_switch_group).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Logical Switch Groups using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_managed_san/c7000.rb
+++ b/lib/puppet/provider/oneview_managed_san/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_managed_san).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Managed SANs using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_managed_san/synergy.rb
+++ b/lib/puppet/provider/oneview_managed_san/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_managed_san).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Managed SANs using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_network_set/synergy.rb
+++ b/lib/puppet/provider/oneview_network_set/synergy.rb
@@ -17,6 +17,7 @@
 Puppet::Type.type(:oneview_network_set).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Network Sets using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 
   def initialize(*args)

--- a/lib/puppet/provider/oneview_power_device/c7000.rb
+++ b/lib/puppet/provider/oneview_power_device/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_power_device).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Power Devices using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_power_device/synergy.rb
+++ b/lib/puppet/provider/oneview_power_device/synergy.rb
@@ -17,6 +17,7 @@
 Puppet::Type.type(:oneview_power_device).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Power Devices using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
   confine true: login[:api_version] >= 300
 end

--- a/lib/puppet/provider/oneview_rack/c7000.rb
+++ b/lib/puppet/provider/oneview_rack/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_rack).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Rack using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_rack/synergy.rb
+++ b/lib/puppet/provider/oneview_rack/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_rack).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Rack using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_resource.rb
+++ b/lib/puppet/provider/oneview_resource.rb
@@ -16,7 +16,6 @@
 
 require_relative 'login'
 require_relative 'common'
-require 'oneview-sdk'
 
 module Puppet
   # Base provider for OneView resources

--- a/lib/puppet/provider/oneview_san_manager/c7000.rb
+++ b/lib/puppet/provider/oneview_san_manager/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_san_manager).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView SAN Manager using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_san_manager/synergy.rb
+++ b/lib/puppet/provider/oneview_san_manager/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_san_manager).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView SAN Manager using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_sas_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_sas_interconnect/synergy.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_sas_interconnect).provide :synergy, parent: Puppet::OneviewResource do
   desc 'Provider for OneView SAS Interconnects using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_sas_logical_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_sas_logical_interconnect/synergy.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_sas_logical_interconnect).provide :synergy, parent: Puppet::OneviewResource do
   desc 'Provider for OneView SAS Logical Interconnects using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_sas_logical_interconnect_group/synergy.rb
+++ b/lib/puppet/provider/oneview_sas_logical_interconnect_group/synergy.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_sas_logical_interconnect_group).provide :synergy, parent: Puppet::OneviewResource do
   desc 'Provider for OneView SAS Logical Interconnect Groups using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_server_hardware/c7000.rb
+++ b/lib/puppet/provider/oneview_server_hardware/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_server_hardware).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Server Hardwares using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_server_hardware/synergy.rb
+++ b/lib/puppet/provider/oneview_server_hardware/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_server_hardware).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Server Hardwares using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_server_hardware_type/c7000.rb
+++ b/lib/puppet/provider/oneview_server_hardware_type/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_server_hardware_type).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Fiber Channel Networks using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_server_hardware_type/synergy.rb
+++ b/lib/puppet/provider/oneview_server_hardware_type/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_server_hardware_type).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Server Hardware Types using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_server_profile/c7000.rb
+++ b/lib/puppet/provider/oneview_server_profile/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_server_profile).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Server Profiles using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_server_profile/synergy.rb
+++ b/lib/puppet/provider/oneview_server_profile/synergy.rb
@@ -17,6 +17,7 @@
 Puppet::Type.type(:oneview_server_profile).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Server Profiles using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 
   # Retrieves all SAS Logical JBOD OR Retrieves a SAS Logical JBOD by name

--- a/lib/puppet/provider/oneview_server_profile_template/synergy.rb
+++ b/lib/puppet/provider/oneview_server_profile_template/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_server_profile_template).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Server Profile Templates using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_storage_pool/c7000.rb
+++ b/lib/puppet/provider/oneview_storage_pool/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_storage_pool).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Storage Pools using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_storage_pool/synergy.rb
+++ b/lib/puppet/provider/oneview_storage_pool/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_storage_pool).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Storage Pools using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_storage_system/c7000.rb
+++ b/lib/puppet/provider/oneview_storage_system/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_storage_system).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Storage Systems using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_storage_system/synergy.rb
+++ b/lib/puppet/provider/oneview_storage_system/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_storage_system).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Storage Systems using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_switch/c7000.rb
+++ b/lib/puppet/provider/oneview_switch/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_switch).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Switch resources using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_switch/synergy.rb
+++ b/lib/puppet/provider/oneview_switch/synergy.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_switch).provide :synergy, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Switch resources using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_unmanaged_device/c7000.rb
+++ b/lib/puppet/provider/oneview_unmanaged_device/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_unmanaged_device).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Unmanaged Devices using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_unmanaged_device/synergy.rb
+++ b/lib/puppet/provider/oneview_unmanaged_device/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_unmanaged_device).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Unmanaged Devices using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_uplink_set/c7000.rb
+++ b/lib/puppet/provider/oneview_uplink_set/c7000.rb
@@ -20,6 +20,7 @@ require 'oneview-sdk'
 Puppet::Type.type(:oneview_uplink_set).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Uplink Sets using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_uplink_set/synergy.rb
+++ b/lib/puppet/provider/oneview_uplink_set/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_uplink_set).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Uplink Sets using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_volume/c7000.rb
+++ b/lib/puppet/provider/oneview_volume/c7000.rb
@@ -22,6 +22,7 @@ Puppet::Type.type(:oneview_volume).provide :c7000, parent: Puppet::OneviewResour
 
   mk_resource_methods
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   # Provider methods

--- a/lib/puppet/provider/oneview_volume/synergy.rb
+++ b/lib/puppet/provider/oneview_volume/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_volume).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Storage Volumes using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_volume_attachment/c7000.rb
+++ b/lib/puppet/provider/oneview_volume_attachment/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_volume_attachment).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Volume Attachments using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_volume_attachment/synergy.rb
+++ b/lib/puppet/provider/oneview_volume_attachment/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_volume_attachment).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Volume Attachments using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/lib/puppet/provider/oneview_volume_template/c7000.rb
+++ b/lib/puppet/provider/oneview_volume_template/c7000.rb
@@ -19,6 +19,7 @@ require_relative '../oneview_resource'
 Puppet::Type.type(:oneview_volume_template).provide :c7000, parent: Puppet::OneviewResource do
   desc 'Provider for OneView Volume Template using the C7000 variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'C7000'
 
   mk_resource_methods

--- a/lib/puppet/provider/oneview_volume_template/synergy.rb
+++ b/lib/puppet/provider/oneview_volume_template/synergy.rb
@@ -17,5 +17,6 @@
 Puppet::Type.type(:oneview_volume_template).provide :synergy, parent: :c7000 do
   desc 'Provider for OneView Volume Template using the Synergy variant of the OneView API'
 
+  confine feature: :oneview
   confine true: login[:hardware_variant] == 'Synergy'
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hewlettpackard-oneview",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": "Hewlett Packard Enterprise",
   "summary": "HPE Puppet providers and types for management of HPE OneView Appliances",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description
Added feature :oneview and confined all providers to this feature.
This will automatically 'require oneview-sdk' for each provider, and will make it so that providers only load if oneview-sdk is available in the system.
This should also avoid catalog errors when running oneview facts without the oneview-sdk installed.

### Issues Resolved
#161 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] Changes are documented in the CHANGELOG.
