### PR TITLE
Updating oneview-sdk version in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'codecov', require: false, group: :test
 gem 'coveralls', '0.8.21', require: false
 gem 'facter', '>= 1.7.0'
 gem 'metadata-json-lint'
-gem 'oneview-sdk', '~> 4.4'
+gem 'oneview-sdk', '~> 5.5.0'
 gem 'pry'
 gem 'puppet', '>= 4.1'
 gem 'puppet-lint', '>= 0.3.2'


### PR DESCRIPTION
### Description
update the oneview-sdk version to 5.5.0 to support api600 endpoints.

### Check List
- [] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
