### PR TITLE
Tested connection template for API version 600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This release extends the full support for the Synergy and C7000 APIs to all the 
 - [#172](https://github.com/HewlettPackard/oneview-puppet/issues/172) Unit tests updated for ruby version 2.4.0 and above.
 
 ### Oneview Features supported
+- Connection template
 - Enclosure group
 - Ethernet network
 - FC network

--- a/examples/connection_template.pp
+++ b/examples/connection_template.pp
@@ -32,7 +32,7 @@ oneview_connection_template{'Connection Template Edit':
   ensure => 'present',
   data   =>
   {
-    name     => 'My CT',
+    name     => 'name1304244267-1467656930023',
     new_name => 'Edited CT'
   }
 }


### PR DESCRIPTION
Added API version 600 support for Connection template.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
