### PR TITLE
Added statement for non-idempotent resources

### DIFF
--- a/lib/puppet/provider/oneview_logical_enclosure/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_enclosure/c7000.rb
@@ -51,7 +51,12 @@ Puppet::Type.type(:oneview_logical_enclosure).provide :c7000, parent: Puppet::On
   end
 
   def updated_from_group
-    get_single_resource_instance.update_from_group
+    resource = get_single_resource_instance
+    if resource.data['state'] == 'Inconsistent'
+      Puppet.notice('Update from Group...')
+      resource.update_from_group
+    end
+    true
   end
 
   def generate_support_dump

--- a/lib/puppet/provider/oneview_logical_interconnect/c7000.rb
+++ b/lib/puppet/provider/oneview_logical_interconnect/c7000.rb
@@ -85,8 +85,11 @@ Puppet::Type.type(:oneview_logical_interconnect).provide :c7000, parent: Puppet:
   end
 
   def set_compliance
-    Puppet.notice('Setting Logical Interconnect compliance...')
-    get_single_resource_instance.compliance
+    resource = get_single_resource_instance
+    if resource.data['consistencyStatus'] == 'NOT_CONSISTENT'
+      Puppet.notice('Setting Logical Interconnect compliance...')
+      resource.compliance
+    end
     true
   end
 

--- a/lib/puppet/provider/oneview_sas_logical_interconnect/synergy.rb
+++ b/lib/puppet/provider/oneview_sas_logical_interconnect/synergy.rb
@@ -57,8 +57,11 @@ Puppet::Type.type(:oneview_sas_logical_interconnect).provide :synergy, parent: P
   end
 
   def set_compliance
-    Puppet.notice('Setting Logical Interconnect compliance...')
-    get_single_resource_instance.compliance
+    resource = get_single_resource_instance
+    if resource.data['consistencyStatus'] == 'NOT_CONSISTENT'
+      Puppet.notice('Setting SAS Logical Interconnect compliance...')
+      resource.compliance
+    end
     true
   end
 


### PR DESCRIPTION
### Description
Added statement for non-idempotent operation.

### Issues Resolved
Before these changes the `oneview_sas_logical_interconnect`, `oneview_logical_interconnect` and `oneview_logical_enclosure` resources will fail the `update_from_group` or `set_compliance` method for several puppet runs with no changes.

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
