### PR TITLE
Adding ipRangeUris and ipv6RangeUris to exception_list

### DIFF
--- a/lib/puppet/provider/uri_parsing.rb
+++ b/lib/puppet/provider/uri_parsing.rb
@@ -38,7 +38,7 @@ end
 def exception_to_be_treated_within_provider(key)
   # TODO: Remove the enclosureUris from this list once the issue(#194) is fixed.
   exception_list = %w(networkUris networkUri hotfixUris fcNetworkUris fcoeNetworkUris connectionUri providerUri
-                      permittedInterconnectTypeUri permittedSwitchTypeUri internalNetworkUris enclosureUris)
+                      permittedInterconnectTypeUri permittedSwitchTypeUri internalNetworkUris enclosureUris ipRangeUris ipv6RangeUris)
   true if exception_list.include?(key)
 end
 


### PR DESCRIPTION
### Description
All Ressources with ipRangeUris or ipv6RangeUris in their parameters won't fail.

### Issues Resolved
#301 

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
