### PR TITLE
issue 315 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.9.1(Unreleased)
 #### Bug fixes & Enhancements:
 - [#301] (https://github.com/HewlettPackard/oneview-puppet/issues/301) Failing to create a oneview enclosure group with ipRangeUris
+- [#315] (https://github.com/HewlettPackard/oneview-puppet/issues/315) Failing to create oneview_server_profile_tempate with connections
 
 # v2.9.0(2020-11-11)
 ### Notes

--- a/lib/puppet/provider/common.rb
+++ b/lib/puppet/provider/common.rb
@@ -115,6 +115,7 @@ end
 # FCoE to be added (no need so far)
 def connections_parse
   @data.each_key do |key|
+    next unless @data[key].is_a?(Hash)
     next unless @data[key].include?('manageConnections')
     @data[key].each do |conn, value|
       next unless conn.include?('connections')


### PR DESCRIPTION
### Description
The Error of the issue only comes up with a Boolean Parameter like in the issue `hideUnusedFlexNics: true` as first child in the data structure of the `oneview_server_profile_template`. So when it comes to the connection_parse function in the `oneview_server_profile_template` provider. https://github.com/HewlettPackard/oneview-puppet/blob/2a0e13d269c3c9cdebf63383e57ec6290d219557/lib/puppet/provider/oneview_server_profile_template/c7000.rb#L27
It iterates over all elements in the data. You can see that in the following. https://github.com/HewlettPackard/oneview-puppet/blob/2a0e13d269c3c9cdebf63383e57ec6290d219557/lib/puppet/provider/common.rb#L117
After that ruby tries to filter each element with an `include?` method to get a Hash with a `manageConnections` key inside it.
https://github.com/HewlettPackard/oneview-puppet/blob/2a0e13d269c3c9cdebf63383e57ec6290d219557/lib/puppet/provider/common.rb#L118
But when ruby tries the `include?` method on `data['hideUnusedFlexNics']` it tries on a TrueClass and you will get the Error in the issue because a  TrueClass don't have such a method. See [ruby docs](https://ruby-doc.org/core-2.4.1/TrueClass.html)

### Issues Resolved
#315 

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
